### PR TITLE
feat(rpc): Re-execute blocks between commits

### DIFF
--- a/vms/saevm/cchain/config.go
+++ b/vms/saevm/cchain/config.go
@@ -76,7 +76,7 @@ type config struct {
 
 	// State & trie
 	Pruning           bool   `json:"pruning-enabled"` // If enabled, trie roots are only persisted every commit-interval blocks.
-	CommitInterval    uint64 `json:"commit-interval"` // HashDB: blocks between trie persistence. Pruning Firewood: max unpersisted revisions.
+	CommitInterval    uint64 `json:"commit-interval"` // HashDB: blocks between trie persistence. Firewood: max unpersisted revisions.
 	TrieCleanCache    uint64 `json:"trie-clean-cache"`
 	SnapshotCache     uint64 `json:"snapshot-cache"`
 	AllowMissingTries bool   `json:"allow-missing-tries"` // If enabled, checks preventing an incomplete trie index are skipped.

--- a/vms/saevm/cchain/config.md
+++ b/vms/saevm/cchain/config.md
@@ -41,7 +41,7 @@ Unrecognized options — a typo, or an option of the pre-SAE C-Chain that no lon
 | Option | Type | Description | Default |
 |--------|------|-------------|---------|
 | `pruning-enabled` | bool | Enable state pruning to save disk space. If disabled, the node runs in archival mode and retains all historical state. | `true` |
-| `commit-interval` | uint64 | For HashDB, the number of blocks between writes of the state trie to disk. For pruning Firewood, the maximum number of unpersisted revisions that can exist at a time. Omit this option to use the default, which Mainnet and Fuji MUST use with HashDB. The node does not accept an explicit `0`. | `4096` |
+| `commit-interval` | uint64 | For HashDB, the number of blocks between writes of the state trie to disk. For Firewood, the maximum number of unpersisted revisions that can exist at a time; an archival Firewood node re-executes recent blocks to serve states not yet persisted. Omit this option to use the default, which Mainnet and Fuji MUST use with HashDB. The node does not accept an explicit `0`. | `4096` |
 | `trie-clean-cache` | int | Size of the trie clean cache in MB. | `512` |
 | `snapshot-cache` | int | Size of the snapshot disk layer clean cache in MB. | `256` |
 | `allow-missing-tries` | bool | Suppress warnings about an incomplete trie index. | `false` |

--- a/vms/saevm/cchain/config.md
+++ b/vms/saevm/cchain/config.md
@@ -41,7 +41,7 @@ Unrecognized options — a typo, or an option of the pre-SAE C-Chain that no lon
 | Option | Type | Description | Default |
 |--------|------|-------------|---------|
 | `pruning-enabled` | bool | Enable state pruning to save disk space. If disabled, the node runs in archival mode and retains all historical state. | `true` |
-| `commit-interval` | uint64 | For HashDB, the number of blocks between writes of the state trie to disk. For Firewood, the maximum number of unpersisted revisions that can exist at a time; an archival Firewood node re-executes recent blocks to serve states not yet persisted. Omit this option to use the default, which Mainnet and Fuji MUST use with HashDB. The node does not accept an explicit `0`. | `4096` |
+| `commit-interval` | uint64 | For HashDB, this sets the number of blocks between state-trie writes to disk. For Firewood, it sets the maximum number of revisions that may remain unpersisted at once. Omit this option to use the default; Mainnet and Fuji MUST use the default with HashDB. The node does not accept an explicit 0. | `4096` |
 | `trie-clean-cache` | int | Size of the trie clean cache in MB. | `512` |
 | `snapshot-cache` | int | Size of the snapshot disk layer clean cache in MB. | `256` |
 | `allow-missing-tries` | bool | Suppress warnings about an incomplete trie index. | `false` |

--- a/vms/saevm/cchain/vm_test.go
+++ b/vms/saevm/cchain/vm_test.go
@@ -268,8 +268,7 @@ func withCommitInterval(n uint64) sutOption {
 	})
 }
 
-// withFirewood selects Firewood as the trie database instead of the default
-// HashDB.
+// withFirewood selects Firewood as the trie database
 func withFirewood() sutOption {
 	return options.Func[sutConfig](func(c *sutConfig) {
 		c.vmConfig.StateScheme = customrawdb.FirewoodScheme

--- a/vms/saevm/cchain/vm_test.go
+++ b/vms/saevm/cchain/vm_test.go
@@ -57,6 +57,7 @@ import (
 	"github.com/ava-labs/avalanchego/version"
 	"github.com/ava-labs/avalanchego/vms/components/avax"
 	"github.com/ava-labs/avalanchego/vms/components/gas"
+	"github.com/ava-labs/avalanchego/vms/evm/sync/customrawdb"
 	"github.com/ava-labs/avalanchego/vms/saevm/blocks"
 	"github.com/ava-labs/avalanchego/vms/saevm/cchain/cchaintest"
 	"github.com/ava-labs/avalanchego/vms/saevm/cchain/dynamic"
@@ -264,6 +265,14 @@ func withArchival() sutOption {
 func withCommitInterval(n uint64) sutOption {
 	return options.Func[sutConfig](func(c *sutConfig) {
 		c.vmConfig.CommitInterval = n
+	})
+}
+
+// withFirewood selects Firewood as the trie database instead of the default
+// HashDB.
+func withFirewood() sutOption {
+	return options.Func[sutConfig](func(c *sutConfig) {
+		c.vmConfig.StateScheme = customrawdb.FirewoodScheme
 	})
 }
 
@@ -1033,6 +1042,57 @@ func TestImport(t *testing.T) {
 	)
 	sut.assertAccount(t, receiver, nonce, tx.ScaleAVAX(amountMinted))
 	sut.assertUTXOsMissing(t, sut.ctx.ChainID, sourceChain, utxo)
+}
+
+func TestStatefulRPCsReconstructExtraState(t *testing.T) {
+	const (
+		commitInterval = 4
+		numBlocks      = 2*commitInterval + 3
+	)
+
+	tests := []struct {
+		name string
+		opts []sutOption
+	}{
+		{
+			name: "hashdb_pruning",
+			opts: []sutOption{withCommitInterval(commitInterval)},
+		},
+		{
+			name: "firewood_commit_interval",
+			opts: []sutOption{withFirewood(), withArchival(), withCommitInterval(commitInterval)},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			key := txtest.NewKey(t)
+			sender := key.EthAddress()
+			timeOpt, clock := withVMTime(testStartTime)
+			opts := []sutOption{withMaxAllocFor(sender), timeOpt, withDB(memdb.New()), withChainDataDir(t.TempDir())}
+			opts = append(opts, tt.opts...)
+
+			ctx, node := newSUT(t, opts...)
+			w := newWallet(key, node.ctx, node.Client)
+			for range numBlocks {
+				blk := node.issueAndExecute(ctx, t, w.newMinimalTx(t))
+				clock.AdvanceToSettle(ctx, t, blk)
+			}
+
+			// Restarting the VM clears all caches so that every uncommitted
+			// state root MUST be reconstructed by re-execution.
+			require.NoErrorf(t, node.Shutdown(ctx), "%T.Shutdown()", node.VM)
+			t.Run("restart", func(t *testing.T) {
+				ctx, sut := newSUT(t, opts...)
+
+				for h := uint64(1); h <= numBlocks; h++ {
+					got, err := sut.ethclient.NonceAt(ctx, sender, new(big.Int).SetUint64(h))
+					require.NoErrorf(t, err, "%T.NonceAt(%d)", sut.ethclient, h)
+					assert.Equalf(t, h, got, "%T.NonceAt(%d): one export per block", sut.ethclient, h)
+				}
+			})
+		})
+	}
 }
 
 // TestBuildBlockOnProcessing verifies that the block builder excludes a mempool

--- a/vms/saevm/firewood/BUILD.bazel
+++ b/vms/saevm/firewood/BUILD.bazel
@@ -6,6 +6,7 @@ go_library(
     srcs = [
         "account_trie.go",
         "base_trie.go",
+        "hasher.go",
         "state.go",
         "storage_trie.go",
         "triedb.go",

--- a/vms/saevm/firewood/README.md
+++ b/vms/saevm/firewood/README.md
@@ -37,15 +37,14 @@ The linear invariant means:
 
 ### Re-execution on Historical State
 
-Firewood can only propose on top of its most recent revision or a not-yet-committed proposal, so a `state.StateDB` opened at any older root could historically be read but not hashed. To allow hashing changes on historical roots, Firewood added `ffi.Reconstructed`, a Rust-side view that applies a batch on top of an `ffi.Revision` and can be read and re-hashed, but never committed.
+Firewood can only propose on top of its most recent revision or a not-yet-committed proposal, so a `state.StateDB` opened at any older root could be read but not hashed. To allow hashing historic state, Firewood added `ffi.Reconstructed`, a Rust-side view that applies a batch on top of an `ffi.Revision` and can be read and hashed, but never committed.
 
 The `state.StateDB` never knows whether it's being used for canonical execution or for an RPC call, so we can't determine which hashable structure to create at construction time. Additionally, the tip state change during use, so it must be updated accordingly at every hash.
 
 Some differences between the proposal and reconstructed implementations:
 
-- **Reconstructions are incremental, proposals are not.** A proposal is rebuilt from the full op list every time the ops grow, whereas a reconstruction only applies the ops added since the last hash. Re-executing many transactions with `IntermediateRoot` between them is therefore comparatively cheap on historical state. A failed `Reconstruct` releases the Rust view, and the next `Hash()` starts over from the revision.
+- **Incremental building** A proposal is rebuilt from the full op list every time the ops grow, whereas a reconstruction can apply the ops added since the last hash. Re-executing many transactions with `IntermediateRoot` between them is therefore comparatively cheap on historical state.
 - **`Copy()` differs by backing.** A proposal-backed copy re-proposes from the parent revision on its next hash, because the pending proposal is invalidated when the original commits it. A reconstruction-backed copy clones the Rust view so it starts from the already-hashed state; the two views then diverge independently.
-- **Which roots are available depends on Firewood's persistence, not on the commit interval alone.** With archival Firewood and a commit interval of `N`, the RPC layer walks back from the requested height until `state.New` succeeds and re-executes the intervening blocks. After a restart, only revisions Firewood actually persisted are available; Firewood persists at least every `N/2` commits and the root at shutdown, so up to roughly `N/2` blocks may need re-execution on a cold node. Blocks are re-executed with `saexec.SkipEndOfBlockOps()` and finalised without committing, and because the reconstruction is never committed, none of this touches disk.
 - **A pending proposal that is never consumed blocks the chain.** `trieCommit` refuses to overwrite `TrieDB.pending`, so if `state.StateDB.Commit` hands a proposal to the `TrieDB` and `TrieDB.Update` then rejects it (for example the parent was no longer the newest root), the next `Commit` from any trie fails with `errProposalPending`. Since there is only one execution thread, this should never be an issue. However, one must never call `state.StateDB.Commit` if it's not canonical execution. If the underlying hasher is a reconstruction, it will also return an error.
 
 ## SELFDESTRUCT Handling

--- a/vms/saevm/firewood/README.md
+++ b/vms/saevm/firewood/README.md
@@ -17,11 +17,11 @@ db := state.NewDatabaseWithConfig(rawdb.NewMemoryDatabase(), &triedb.Config{
 
 ## Rust Memory Management
 
-Firewood's CGo FFI exposes two types of Rust-owned heap objects: `ffi.Revision` and `ffi.Proposal`. Both should be explicitly freed to avoid leaking Rust memory - otherwise we must rely on Go's garbage collector to eventually call `runtime.AddCleanup`.
+Firewood's CGo FFI exposes three types of Rust-owned heap objects: `ffi.Revision`, `ffi.Proposal`, and `ffi.Reconstructed`. In most cases, we must rely on Go's garbage collector to eventually call `runtime.AddCleanup`. If possible, these should be explicitly freed.
 
-Proposals tracked by the `TrieDB` are freed when committed. Any remaining handles (pending or committable proposals, and revisions held by tries) are force-closed on the Rust side by `TrieDB.Close`, which calls `ffi.Close` with `ffi.WithForceCloseHandles()`.
+Proposals tracked by the `TrieDB` are freed when committed. Any remaining handles (pending or committable proposals, and revisions or reconstructions held by tries) are force-closed on the Rust side by `TrieDB.Close`, which calls `ffi.Close` with `ffi.WithForceCloseHandles()`.
 
-Revisions are, in general, freed via `runtime.AddCleanup`, because the `state.Trie` implementation does not have a `Close` method or anything similar. Outstanding trie references need not be garbage collected before `TrieDB.Close()`, but they are invalid afterward and must not be used. Users must be conscious that holding a `state.Trie` for longer than necessary can easily lead to a memory leak within Firewood.
+Revisions and reconstructions are, in general, freed via `runtime.AddCleanup`, because the `state.Trie` implementation does not have a `Close` method or anything similar. Outstanding trie references need not be garbage collected before `TrieDB.Close()`, but they are invalid afterward and must not be used. Users must be conscious that holding a `state.Trie` for longer than necessary can easily lead to a memory leak within Firewood.
 
 ## Operation Model
 
@@ -33,7 +33,20 @@ The linear invariant means:
 
 - Any proposal created via `accountTrie.Hash()` will be tracked in `accountTrie.Commit()`, and **must** then be moved to the committable map in `TrieDB.Update`.
 - The parent of each new proposal must be either the current committed tip of the Firewood database or the most recent uncommitted proposal in the chain.
-- Branching — creating two proposals from the same parent — is not supported.
+- Any revision can have arbitrarily many hashable (i.e. either `ffi.Reconstructed` or `ffi.Proposal`) built on top of it, but only a single proposal can ever be committed.
+
+### Re-execution on Historical State
+
+Firewood can only propose on top of its most recent revision or a not-yet-committed proposal, so a `state.StateDB` opened at any older root could historically be read but not hashed. To allow hashing changes on historical roots, Firewood added `ffi.Reconstructed`, a Rust-side view that applies a batch on top of an `ffi.Revision` and can be read and re-hashed, but never committed.
+
+The `state.StateDB` never knows whether it's being used for canonical execution or for an RPC call, so we can't determine which hashable structure to create at construction time. Additionally, the tip state change during use, so it must be updated accordingly at every hash.
+
+Some differences between the proposal and reconstructed implementations:
+
+- **Reconstructions are incremental, proposals are not.** A proposal is rebuilt from the full op list every time the ops grow, whereas a reconstruction only applies the ops added since the last hash. Re-executing many transactions with `IntermediateRoot` between them is therefore comparatively cheap on historical state. A failed `Reconstruct` releases the Rust view, and the next `Hash()` starts over from the revision.
+- **`Copy()` differs by backing.** A proposal-backed copy re-proposes from the parent revision on its next hash, because the pending proposal is invalidated when the original commits it. A reconstruction-backed copy clones the Rust view so it starts from the already-hashed state; the two views then diverge independently.
+- **Which roots are available depends on Firewood's persistence, not on the commit interval alone.** With archival Firewood and a commit interval of `N`, the RPC layer walks back from the requested height until `state.New` succeeds and re-executes the intervening blocks. After a restart, only revisions Firewood actually persisted are available; Firewood persists at least every `N/2` commits and the root at shutdown, so up to roughly `N/2` blocks may need re-execution on a cold node. Blocks are re-executed with `saexec.SkipEndOfBlockOps()` and finalised without committing, and because the reconstruction is never committed, none of this touches disk.
+- **A pending proposal that is never consumed blocks the chain.** `trieCommit` refuses to overwrite `TrieDB.pending`, so if `state.StateDB.Commit` hands a proposal to the `TrieDB` and `TrieDB.Update` then rejects it (for example the parent was no longer the newest root), the next `Commit` from any trie fails with `errProposalPending`. Since there is only one execution thread, this should never be an issue. However, one must never call `state.StateDB.Commit` if it's not canonical execution. If the underlying hasher is a reconstruction, it will also return an error.
 
 ## SELFDESTRUCT Handling
 

--- a/vms/saevm/firewood/README.md
+++ b/vms/saevm/firewood/README.md
@@ -17,9 +17,9 @@ db := state.NewDatabaseWithConfig(rawdb.NewMemoryDatabase(), &triedb.Config{
 
 ## Rust Memory Management
 
-Firewood's CGo FFI exposes three types of Rust-owned heap objects: `ffi.Revision`, `ffi.Proposal`, and `ffi.Reconstructed`. In most cases, we must rely on Go's garbage collector to eventually call `runtime.AddCleanup`. If possible, these should be explicitly freed.
+Firewood's CGo FFI exposes three types of Rust-owned heap objects: `ffi.Revision`, `ffi.Proposal`, and `ffi.Reconstructed`. In most cases, we must rely on Go's garbage collector. If possible, these should be explicitly freed.
 
-Proposals tracked by the `TrieDB` are freed when committed. Any remaining handles (pending or committable proposals, and revisions or reconstructions held by tries) are force-closed on the Rust side by `TrieDB.Close`, which calls `ffi.Close` with `ffi.WithForceCloseHandles()`.
+Proposals tracked by the `TrieDB` are freed when committed. Any remaining handles (pending/committable proposals, and revisions/reconstructions held by tries) are force-closed on the Rust side by `TrieDB.Close`, which calls `ffi.Close` with `ffi.WithForceCloseHandles()`.
 
 Revisions and reconstructions are, in general, freed via `runtime.AddCleanup`, because the `state.Trie` implementation does not have a `Close` method or anything similar. Outstanding trie references need not be garbage collected before `TrieDB.Close()`, but they are invalid afterward and must not be used. Users must be conscious that holding a `state.Trie` for longer than necessary can easily lead to a memory leak within Firewood.
 
@@ -33,19 +33,19 @@ The linear invariant means:
 
 - Any proposal created via `accountTrie.Hash()` will be tracked in `accountTrie.Commit()`, and **must** then be moved to the committable map in `TrieDB.Update`.
 - The parent of each new proposal must be either the current committed tip of the Firewood database or the most recent uncommitted proposal in the chain.
-- Any revision can have arbitrarily many hashable (i.e. either `ffi.Reconstructed` or `ffi.Proposal`) built on top of it, but only a single proposal can ever be committed.
+- Any revision can have arbitrarily many hashable items (i.e. either `ffi.Reconstructed` or `ffi.Proposal`) built on top of it, but only a single proposal can ever be committed.
 
 ### Re-execution on Historical State
 
-Firewood can only propose on top of its most recent revision or a not-yet-committed proposal, so a `state.StateDB` opened at any older root could be read but not hashed. To allow hashing historic state, Firewood added `ffi.Reconstructed`, a Rust-side view that applies a batch on top of an `ffi.Revision` and can be read and hashed, but never committed.
+Firewood can only propose on top of its most recent revision or a not-yet-committed proposal, so a `state.StateDB` opened at any older root can be read but not hashed. To allow hashing historic state, Firewood has `ffi.Reconstructed`, a Rust-side view that applies a batch on top of an `ffi.Revision` and can be read and hashed, but never committed.
 
 The `state.StateDB` never knows whether it's being used for canonical execution or for an RPC call, so we can't determine which hashable structure to create at construction time. Additionally, the tip state change during use, so it must be updated accordingly at every hash.
 
 Some differences between the proposal and reconstructed implementations:
 
 - **Incremental building** A proposal is rebuilt from the full op list every time the ops grow, whereas a reconstruction can apply the ops added since the last hash. Re-executing many transactions with `IntermediateRoot` between them is therefore comparatively cheap on historical state.
-- **`Copy()` differs by backing.** A proposal-backed copy re-proposes from the parent revision on its next hash, because the pending proposal is invalidated when the original commits it. A reconstruction-backed copy clones the Rust view so it starts from the already-hashed state; the two views then diverge independently.
-- **A pending proposal that is never consumed blocks the chain.** `trieCommit` refuses to overwrite `TrieDB.pending`, so if `state.StateDB.Commit` hands a proposal to the `TrieDB` and `TrieDB.Update` then rejects it (for example the parent was no longer the newest root), the next `Commit` from any trie fails with `errProposalPending`. Since there is only one execution thread, this should never be an issue. However, one must never call `state.StateDB.Commit` if it's not canonical execution. If the underlying hasher is a reconstruction, it will also return an error.
+- **`Copy()` semantics** A proposal-backed copy re-proposes from the parent revision on its next hash, because the pending proposal is invalidated when the original commits it. A reconstruction-backed can directly clone the reconstruction, avoiding re-hashing in the future.
+- **`state.Trie.Commit` impacts** `trieCommit` refuses to overwrite `TrieDB.pending`, so if `state.StateDB.Commit` hands a proposal to the `TrieDB` and `TrieDB.Update` then rejects it (for example the parent was no longer the newest root), the next `Commit` from any trie fails with `errProposalPending`. Since there is only one execution thread, this should never be an issue. However, one must never call `state.StateDB.Commit` if it's not canonical execution. If the underlying hasher is a reconstruction, it will also return an error.
 
 ## SELFDESTRUCT Handling
 

--- a/vms/saevm/firewood/account_trie.go
+++ b/vms/saevm/firewood/account_trie.go
@@ -5,13 +5,12 @@ package firewood
 
 import (
 	"errors"
+	"fmt"
 	"slices"
 
 	"github.com/ava-labs/firewood-go-ethhash/ffi"
 	"github.com/ava-labs/libevm/common"
 	"github.com/ava-labs/libevm/core/state"
-	"github.com/ava-labs/libevm/ethdb"
-	"github.com/ava-labs/libevm/trie"
 	"github.com/ava-labs/libevm/trie/trienode"
 	"go.uber.org/zap"
 )
@@ -24,8 +23,11 @@ var _ state.Trie = (*accountTrie)(nil)
 //     values, and we thus rely on the shared [baseTrie]. Additionally, no [trienode.NodeSet] is
 //     actually constructed, since Firewood manages nodes internally and the list of changes
 //     is not needed externally.
-//  2. The [accountTrie.Hash] method actually creates the [ffi.Proposal], since Firewood cannot calculate
-//     the hash of the trie without committing it.
+//  2. The [accountTrie.Hash] method actually applies the changes to Firewood, since Firewood cannot
+//     calculate the hash of the trie otherwise. If the parent root can be proposed on (it is the
+//     Firewood tip or a not-yet-committed proposal), an [ffi.Proposal] is created so that the changes
+//     can later be committed. Otherwise, an [ffi.Reconstructed] view over the historical revision is
+//     built, which can be read and hashed but never committed. See [hasher].
 //  3. the [accountTrie.GetAccount] and [accountTrie.GetStorage] methods cannot read from changes since
 //     the most recent call to [accountTrie.Hash], and this is a very difficult problem to solve due
 //     to account deletions on the `SELFDESTRUCT` opcode not manually calling [state.Trie.DeleteStorage].
@@ -35,67 +37,60 @@ var _ state.Trie = (*accountTrie)(nil)
 // Note this is not concurrent safe.
 type accountTrie struct {
 	*baseTrie
-	parentRoot       common.Hash
-	root             common.Hash
-	pending          *ffi.Proposal
-	tdb              *TrieDB
-	lastProposalSize int
+	revision *ffi.Revision
+	hasher   hasher
+	tdb      *TrieDB
 }
 
 func newAccountTrie(root common.Hash, db *TrieDB, currentOps []ffi.BatchOp) (*accountTrie, error) {
-	reader, err := db.Firewood.Revision(ffi.Hash(root))
-	switch {
-	case errors.Is(err, ffi.ErrRevisionNotFound):
-		return nil, &trie.MissingNodeError{NodeHash: root}
-	case err != nil:
+	revision, err := db.newRevision(root)
+	if err != nil {
 		return nil, err
 	}
-
-	return &accountTrie{
-		baseTrie:   &baseTrie{reader: reader, updateOps: currentOps},
-		parentRoot: root,
-		root:       root,
-		tdb:        db,
-	}, nil
+	hasher := newProposalHasher(db, root, revision)
+	return newAccountTrieWithHasher(revision, hasher, db, currentOps), nil
 }
 
-// Hash returns the current hash of the state trie.
-// This will create the necessary proposals to guarantee that the changes can
-// later be committed. Any new proposal will be tracked by the accountTrie
-// until a call to [accountTrie.Commit].
+func newAccountTrieWithHasher(revision *ffi.Revision, h hasher, db *TrieDB, currentOps []ffi.BatchOp) *accountTrie {
+	return &accountTrie{
+		baseTrie: &baseTrie{reader: h, updateOps: currentOps},
+		revision: revision,
+		hasher:   h,
+		tdb:      db,
+	}
+}
+
+// Hash returns the current hash of the state trie. This will apply any changes
+// since the last call, which permits future calls to [accountTrie.Commit] if
+// the changes are proposed on top of the tip of state.
 //
-// Any proposals created by this method will be freed once the accountTrie
-// is garbage collected.
+// Any Firewood handles created by this method will be freed once the
+// accountTrie is garbage collected.
 //
 // Hash cannot return an error, so if any error is encountered, it will be
 // logged at error level and the zero hash is returned.
 func (a *accountTrie) Hash() common.Hash {
-	if err := a.updateProposal(); err != nil {
+	root, err := a.hash()
+	if err != nil {
 		a.tdb.log.Error("hashing account trie", zap.Error(err))
 		return common.Hash{}
 	}
-	return a.root
+	return root
 }
 
-// updateProposal checks whether the pending proposal is out of date, and if it
-// is, creates a new proposal with the addiotional changes and updates the
-// internal state.
-func (a *accountTrie) updateProposal() error {
-	if a.lastProposalSize == len(a.updateOps) {
-		return nil
+// hash applies all pending updates via the [hasher] and returns the root. If the
+// previous root was a historical revision,  an [ffi.Reconstruction] will be made.
+func (a *accountTrie) hash() (common.Hash, error) {
+	root, err := a.hasher.hash(a.updateOps)
+	if !errors.Is(err, errNotProposable) {
+		return root, err
 	}
 
-	proposal, err := a.tdb.newProposal(a.parentRoot, a.updateOps)
-	// TODO(#5506): Create [ffi.Reconstructed] to allow stateful RPCs.
-	if err != nil {
-		return err
-	}
-
-	a.pending = proposal
-	a.reader = proposal
-	a.root = common.Hash(proposal.Root())
-	a.lastProposalSize = len(a.updateOps) // Avoid re-hashing until next update
-	return nil
+	// Reads by the shared [baseTrie] (and so by every [storageTrie]) MUST
+	// follow the new hasher.
+	a.hasher = newReconstructedHasher(a.revision)
+	a.reader = a.hasher
+	return a.hasher.hash(a.updateOps)
 }
 
 // Commit returns the new root hash of the trie and a nil [trienode.NodeSet].
@@ -108,36 +103,24 @@ func (a *accountTrie) updateProposal() error {
 // the values as a leaf in the nodeset (corresponding to whether the caller
 // expects this to be an account trie or not).
 func (a *accountTrie) Commit(bool) (common.Hash, *trienode.NodeSet, error) {
-	if err := a.updateProposal(); err != nil {
+	root, err := a.hash()
+	if err != nil {
 		return common.Hash{}, nil, err
 	}
 
-	// The [state.StateDB] only calls [triedb.Database.Update] when the root
-	// differs from the parent. Also, a.pending is only non-nil when the root
-	// has changed.
-	if a.root != a.parentRoot {
-		a.tdb.trieCommit(a.pending)
+	if err := a.hasher.commit(); err != nil {
+		return common.Hash{}, nil, fmt.Errorf("committing account trie: %w", err)
 	}
-	return a.root, nil, nil
-}
 
-// Prove writes the inclusion or exclusion proof for the already hashed key to
-// the provided writer.
-//
-// TODO(alarso16): Implement.
-func (*accountTrie) Prove([]byte, ethdb.KeyValueWriter) error {
-	return errProveNotImplemented
+	return root, nil, nil
 }
 
 // Copy creates a copy of the [accountTrie].
 func (a *accountTrie) Copy() *accountTrie {
-	// This revision MUST be copied because it could refer to a proposal held
-	// by this account trie. If the proposal is committed, the reader will no
-	// no longer be valid. However, an [ffi.Revision] will still be valid.
-	tr, err := newAccountTrie(a.parentRoot, a.tdb, slices.Clone(a.updateOps))
+	h, err := a.hasher.copy()
 	if err != nil {
 		a.tdb.log.Error("copying account trie", zap.Error(err))
 		return nil
 	}
-	return tr
+	return newAccountTrieWithHasher(a.revision, h, a.tdb, slices.Clone(a.updateOps))
 }

--- a/vms/saevm/firewood/account_trie.go
+++ b/vms/saevm/firewood/account_trie.go
@@ -102,6 +102,9 @@ func (a *accountTrie) hash() (common.Hash, error) {
 // [ffi.Proposal]. The boolean input was intended to indicate whether to add
 // the values as a leaf in the nodeset (corresponding to whether the caller
 // expects this to be an account trie or not).
+//
+// Commit returns an error if the parent root cannot be proposed on, since such
+// state can never be committed.
 func (a *accountTrie) Commit(bool) (common.Hash, *trienode.NodeSet, error) {
 	root, err := a.hash()
 	if err != nil {

--- a/vms/saevm/firewood/account_trie.go
+++ b/vms/saevm/firewood/account_trie.go
@@ -86,9 +86,11 @@ func (a *accountTrie) hash() (common.Hash, error) {
 		return root, err
 	}
 
-	// Reads by the shared [baseTrie] (and so by every [storageTrie]) MUST
-	// follow the new hasher.
-	a.hasher = newReconstructedHasher(a.revision)
+	recon, err := a.tdb.newReconstructed(common.Hash(a.revision.Root()))
+	if err != nil {
+		return common.Hash{}, err
+	}
+	a.hasher = newReconstructedHasher(recon)
 	a.reader = a.hasher
 	return a.hasher.hash(a.updateOps)
 }

--- a/vms/saevm/firewood/account_trie.go
+++ b/vms/saevm/firewood/account_trie.go
@@ -79,7 +79,7 @@ func (a *accountTrie) Hash() common.Hash {
 }
 
 // hash applies all pending updates via the [hasher] and returns the root. If the
-// previous root was a historical revision,  an [ffi.Reconstruction] will be made.
+// previous root was a historical revision, an [ffi.Reconstructed] will be made.
 func (a *accountTrie) hash() (common.Hash, error) {
 	root, err := a.hasher.hash(a.updateOps)
 	if !errors.Is(err, errNotProposable) {

--- a/vms/saevm/firewood/base_trie.go
+++ b/vms/saevm/firewood/base_trie.go
@@ -10,6 +10,7 @@ import (
 	"github.com/ava-labs/libevm/common"
 	"github.com/ava-labs/libevm/core/types"
 	"github.com/ava-labs/libevm/crypto"
+	"github.com/ava-labs/libevm/ethdb"
 	"github.com/ava-labs/libevm/rlp"
 	"github.com/ava-labs/libevm/trie"
 )
@@ -33,13 +34,7 @@ func storageKey(addr common.Address, key []byte) []byte {
 
 type trieReader interface {
 	Get([]byte) ([]byte, error)
-	Drop() error
 }
-
-var (
-	_ trieReader = (*ffi.Revision)(nil)
-	_ trieReader = (*ffi.Proposal)(nil)
-)
 
 // baseTrie contains the shared state and methods for all Firewood
 // trie implementations. It provides the read/write operations that are
@@ -144,4 +139,10 @@ var (
 // snapshots or offline pruning.
 func (*baseTrie) NodeIterator([]byte) (trie.NodeIterator, error) {
 	return nil, errNodeIteratorNotImplemented
+}
+
+// Prove writes the inclusion or exclusion proof for the already hashed key to
+// the provided writer.
+func (*baseTrie) Prove([]byte, ethdb.KeyValueWriter) error {
+	return errProveNotImplemented
 }

--- a/vms/saevm/firewood/hasher.go
+++ b/vms/saevm/firewood/hasher.go
@@ -127,7 +127,7 @@ func (r *reconstructedHasher) hash(ops []ffi.BatchOp) (common.Hash, error) {
 	}
 
 	if err := r.view.Reconstruct(ops[r.applied:]); err != nil {
-		// On error, the [ffi.Reconstruction] has released its resources and is no longer
+		// On error, the [ffi.Reconstructed] has released its resources and is no longer
 		// usable.
 		r.view = nil
 		r.applied = 0

--- a/vms/saevm/firewood/hasher.go
+++ b/vms/saevm/firewood/hasher.go
@@ -10,8 +10,6 @@ import (
 	"github.com/ava-labs/libevm/common"
 )
 
-var errHistoricalNotCommittable = errors.New("state built on a historical revision cannot be committed")
-
 // hasher serves reads from, and computes the root of, a parent state with the
 // trie's pending updates applied. Exactly one hasher backs each [accountTrie].
 //
@@ -36,9 +34,9 @@ type proposalHasher struct {
 	parentRoot common.Hash
 	revision   *ffi.Revision
 
-	pending  *ffi.Proposal
-	proposed int         // len(ops) reflected by pending
-	root     common.Hash // root of pending, or parentRoot if pending is nil
+	pending  *ffi.Proposal // MAY be nil
+	proposed int           // len(ops) reflected by pending
+	root     common.Hash   // root of pending, or parentRoot if pending is nil
 }
 
 func newProposalHasher(tdb *TrieDB, parentRoot common.Hash, revision *ffi.Revision) *proposalHasher {
@@ -96,54 +94,32 @@ func (p *proposalHasher) copy() (hasher, error) {
 // reconstructedHasher hashes by building an [ffi.Reconstructed] view on top of
 // a historical revision that can no longer be proposed on.
 type reconstructedHasher struct {
-	revision *ffi.Revision
-
 	view    *ffi.Reconstructed
 	applied int // len(ops) reflected by view
 }
 
-func newReconstructedHasher(revision *ffi.Revision) *reconstructedHasher {
-	return &reconstructedHasher{revision: revision}
+func newReconstructedHasher(recon *ffi.Reconstructed) *reconstructedHasher {
+	return &reconstructedHasher{view: recon}
 }
 
 func (r *reconstructedHasher) Get(key []byte) ([]byte, error) {
-	if r.view != nil {
-		return r.view.Get(key)
-	}
-	return r.revision.Get(key)
+	return r.view.Get(key)
 }
 
 func (r *reconstructedHasher) hash(ops []ffi.BatchOp) (common.Hash, error) {
 	if len(ops) == r.applied {
-		return r.root(), nil
-	}
-
-	if r.view == nil {
-		view, err := r.revision.Reconstruct(nil)
-		if err != nil {
-			return common.Hash{}, err
-		}
-		r.view = view
+		return common.Hash(r.view.Root()), nil
 	}
 
 	if err := r.view.Reconstruct(ops[r.applied:]); err != nil {
-		// On error, the [ffi.Reconstructed] has released its resources and is no longer
-		// usable.
-		r.view = nil
-		r.applied = 0
 		return common.Hash{}, err
 	}
 
 	r.applied = len(ops)
-	return r.root(), nil
+	return common.Hash(r.view.Root()), nil
 }
 
-func (r *reconstructedHasher) root() common.Hash {
-	if r.view != nil {
-		return common.Hash(r.view.Root())
-	}
-	return common.Hash(r.revision.Root())
-}
+var errHistoricalNotCommittable = errors.New("state built on a historical revision cannot be committed")
 
 func (*reconstructedHasher) commit() error {
 	return errHistoricalNotCommittable
@@ -152,16 +128,12 @@ func (*reconstructedHasher) commit() error {
 // copy clones the reconstructed view, if any, so the copy starts from the
 // already-hashed state instead of replaying every op.
 func (r *reconstructedHasher) copy() (hasher, error) {
-	cp := newReconstructedHasher(r.revision)
-	if r.view == nil {
-		return cp, nil
-	}
-
-	view, err := r.view.Clone()
+	recon, err := r.view.Clone()
 	if err != nil {
 		return nil, err
 	}
-	cp.view = view
+
+	cp := newReconstructedHasher(recon)
 	cp.applied = r.applied
 	return cp, nil
 }

--- a/vms/saevm/firewood/hasher.go
+++ b/vms/saevm/firewood/hasher.go
@@ -1,0 +1,167 @@
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
+// See the file LICENSE for licensing terms.
+
+package firewood
+
+import (
+	"errors"
+
+	"github.com/ava-labs/firewood-go-ethhash/ffi"
+	"github.com/ava-labs/libevm/common"
+)
+
+var errHistoricalNotCommittable = errors.New("state built on a historical revision cannot be committed")
+
+// hasher serves reads from, and computes the root of, a parent state with the
+// trie's pending updates applied. Exactly one hasher backs each [accountTrie].
+//
+// Not concurrent-safe.
+type hasher interface {
+	trieReader
+	hash(ops []ffi.BatchOp) (common.Hash, error)
+	commit() error
+	copy() (hasher, error)
+}
+
+var (
+	_ hasher = (*proposalHasher)(nil)
+	_ hasher = (*reconstructedHasher)(nil)
+)
+
+// proposalHasher hashes by creating an [ffi.Proposal] on top of a parent that
+// is either the Firewood tip or a not-yet-committed proposal tracked by the
+// [TrieDB]. Its result can later be committed.
+type proposalHasher struct {
+	tdb        *TrieDB
+	parentRoot common.Hash
+	revision   *ffi.Revision
+
+	pending  *ffi.Proposal
+	proposed int         // len(ops) reflected by pending
+	root     common.Hash // root of pending, or parentRoot if pending is nil
+}
+
+func newProposalHasher(tdb *TrieDB, parentRoot common.Hash, revision *ffi.Revision) *proposalHasher {
+	return &proposalHasher{
+		tdb:        tdb,
+		parentRoot: parentRoot,
+		revision:   revision,
+		root:       parentRoot,
+	}
+}
+
+func (p *proposalHasher) Get(key []byte) ([]byte, error) {
+	if p.pending != nil {
+		return p.pending.Get(key)
+	}
+	return p.revision.Get(key)
+}
+
+// hash re-proposes the full set of ops on top of the parent whenever ops has
+// grown since the last proposal. Any previous proposal is freed once garbage
+// collected.
+func (p *proposalHasher) hash(ops []ffi.BatchOp) (common.Hash, error) {
+	if len(ops) == p.proposed {
+		return p.root, nil
+	}
+
+	proposal, err := p.tdb.newProposal(p.parentRoot, ops)
+	if err != nil {
+		return common.Hash{}, err
+	}
+
+	p.pending = proposal
+	p.proposed = len(ops)
+	p.root = common.Hash(proposal.Root())
+	return p.root, nil
+}
+
+func (p *proposalHasher) commit() error {
+	// The [state.StateDB] only calls [triedb.Database.Update] when the root
+	// differs from the parent, which is the only case in which there are
+	// changes to commit.
+	if p.root == p.parentRoot {
+		return nil
+	}
+	return p.tdb.trieCommit(p.pending)
+}
+
+// copy returns a hasher that reads from the parent revision and re-proposes
+// all ops on its next hash. It MUST NOT share the pending proposal, which
+// becomes invalid once the original commits it.
+func (p *proposalHasher) copy() (hasher, error) {
+	return newProposalHasher(p.tdb, p.parentRoot, p.revision), nil
+}
+
+// reconstructedHasher hashes by building an [ffi.Reconstructed] view on top of
+// a historical revision that can no longer be proposed on.
+type reconstructedHasher struct {
+	revision *ffi.Revision
+
+	view    *ffi.Reconstructed
+	applied int // len(ops) reflected by view
+}
+
+func newReconstructedHasher(revision *ffi.Revision) *reconstructedHasher {
+	return &reconstructedHasher{revision: revision}
+}
+
+func (r *reconstructedHasher) Get(key []byte) ([]byte, error) {
+	if r.view != nil {
+		return r.view.Get(key)
+	}
+	return r.revision.Get(key)
+}
+
+func (r *reconstructedHasher) hash(ops []ffi.BatchOp) (common.Hash, error) {
+	if len(ops) == r.applied {
+		return r.root(), nil
+	}
+
+	if r.view == nil {
+		view, err := r.revision.Reconstruct(nil)
+		if err != nil {
+			return common.Hash{}, err
+		}
+		r.view = view
+	}
+
+	if err := r.view.Reconstruct(ops[r.applied:]); err != nil {
+		// On error, the [ffi.Reconstruction] has released its resources and is no longer
+		// usable.
+		r.view = nil
+		r.applied = 0
+		return common.Hash{}, err
+	}
+
+	r.applied = len(ops)
+	return r.root(), nil
+}
+
+func (r *reconstructedHasher) root() common.Hash {
+	if r.view != nil {
+		return common.Hash(r.view.Root())
+	}
+	return common.Hash(r.revision.Root())
+}
+
+func (*reconstructedHasher) commit() error {
+	return errHistoricalNotCommittable
+}
+
+// copy clones the reconstructed view, if any, so the copy starts from the
+// already-hashed state instead of replaying every op.
+func (r *reconstructedHasher) copy() (hasher, error) {
+	cp := newReconstructedHasher(r.revision)
+	if r.view == nil {
+		return cp, nil
+	}
+
+	view, err := r.view.Clone()
+	if err != nil {
+		return nil, err
+	}
+	cp.view = view
+	cp.applied = r.applied
+	return cp, nil
+}

--- a/vms/saevm/firewood/storage_trie.go
+++ b/vms/saevm/firewood/storage_trie.go
@@ -6,7 +6,6 @@ package firewood
 import (
 	"github.com/ava-labs/libevm/common"
 	"github.com/ava-labs/libevm/core/state"
-	"github.com/ava-labs/libevm/ethdb"
 	"github.com/ava-labs/libevm/trie/trienode"
 
 	_ "github.com/ava-labs/firewood-go-ethhash/ffi" // comment resolution
@@ -47,12 +46,4 @@ func (*storageTrie) Commit(bool) (common.Hash, *trienode.NodeSet, error) {
 // debug APIs that SAE doesn't support.
 func (*storageTrie) Hash() common.Hash {
 	return common.Hash{}
-}
-
-// Prove writes the inclusion or exclusion proof for the already hashed key to
-// the provided writer.
-//
-// TODO(alarso16): Implement.
-func (*storageTrie) Prove([]byte, ethdb.KeyValueWriter) error {
-	return errProveNotImplemented
 }

--- a/vms/saevm/firewood/triedb.go
+++ b/vms/saevm/firewood/triedb.go
@@ -302,6 +302,14 @@ func (t *TrieDB) newProposal(parentRoot common.Hash, batchOps []ffi.BatchOp) (*f
 	}
 }
 
+func (t *TrieDB) newReconstructed(root common.Hash) (*ffi.Reconstructed, error) {
+	rev, err := t.newRevision(root)
+	if err != nil {
+		return nil, err
+	}
+	return rev.Reconstruct(nil)
+}
+
 var errProposalPending = errors.New("a proposal is already pending")
 
 // trieCommit considers the provided proposal as canonical, to be consumed by

--- a/vms/saevm/firewood/triedb.go
+++ b/vms/saevm/firewood/triedb.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"sync"
 	"time"
 
 	"github.com/ava-labs/firewood-go-ethhash/ffi"
@@ -15,15 +16,14 @@ import (
 	"github.com/ava-labs/libevm/core/types"
 	"github.com/ava-labs/libevm/ethdb"
 	"github.com/ava-labs/libevm/libevm/stateconf"
+	"github.com/ava-labs/libevm/trie"
 	"github.com/ava-labs/libevm/trie/trienode"
 	"github.com/ava-labs/libevm/trie/triestate"
 	"github.com/ava-labs/libevm/triedb"
 	"github.com/ava-labs/libevm/triedb/database"
 	"go.uber.org/zap"
 
-	// comment resolution
-	_ "github.com/ava-labs/libevm/core/state"
-	_ "github.com/ava-labs/libevm/trie"
+	_ "github.com/ava-labs/libevm/core/state" // comment resolution
 
 	"github.com/ava-labs/avalanchego/utils/linked"
 	"github.com/ava-labs/avalanchego/utils/logging"
@@ -114,6 +114,7 @@ type TrieDB struct {
 	// and the latest state can be modified at any time during execution.
 	Firewood *ffi.Database
 
+	mu          sync.RWMutex
 	pending     *ffi.Proposal
 	committable *linked.Hashmap[common.Hash, *ffi.Proposal]
 
@@ -160,6 +161,8 @@ func New(config Config) (*TrieDB, error) {
 func (t *TrieDB) Close() error {
 	// The force close below will iterate through all open handles and free
 	// their Rust-side memory explicitly
+	t.mu.Lock()
+	defer t.mu.Unlock()
 	t.committable.Clear()
 	t.pending = nil
 
@@ -184,6 +187,8 @@ func (t *TrieDB) Initialized(genesisRoot common.Hash) bool {
 	return common.Hash(t.Firewood.Root()) != types.EmptyRootHash
 }
 
+var errParentNotLatest = errors.New("proposal parent is not the latest root")
+
 // Update considers the given root as the new head of tracked roots.  This root,
 // if different than parent, must have been created via [state.Trie.Commit] with
 // a Firewood-backed [state.StateDB]. After Update returns, the user can call
@@ -191,10 +196,23 @@ func (t *TrieDB) Initialized(genesisRoot common.Hash) bool {
 //
 //nolint:revive // removing names loses context.
 func (t *TrieDB) Update(root common.Hash, parent common.Hash, block uint64, nodes *trienode.MergedNodeSet, states *triestate.Set, _ ...stateconf.TrieDBUpdateOption) error {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+
 	possible := t.pending
 	if possible == nil {
 		// Update will never be called if no state change is proposed.
 		return fmt.Errorf("no pending proposal to update for root %s", root)
+	}
+
+	// Proposals form a linear chain, so the parent MUST be the newest root
+	// tracked here.
+	latest, _, ok := t.committable.Newest()
+	if !ok {
+		latest = common.Hash(t.Firewood.Root())
+	}
+	if parent != latest {
+		return fmt.Errorf("%w: parent %s, latest %s", errParentNotLatest, parent, latest)
 	}
 
 	if gotRoot := common.Hash(possible.Root()); gotRoot != root {
@@ -215,6 +233,9 @@ func (t *TrieDB) Update(root common.Hash, parent common.Hash, block uint64, node
 //
 // Any error returned from this function should be treated as fatal.
 func (t *TrieDB) Commit(root common.Hash, report bool) error {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+
 	if _, ok := t.committable.Get(root); !ok {
 		// Ideally, one would check that the root is on disk, since one should
 		// never pass a non-existent root to Commit. However, Firewood loses
@@ -253,24 +274,49 @@ func (t *TrieDB) Commit(root common.Hash, report bool) error {
 	return nil
 }
 
-// newProposal creates a new proposal from either a committable proposal or the tip of the database.
+// newRevision returns the [ffi.Revision] at root, or a [trie.MissingNodeError]
+// if Firewood has no revision for root.
+func (t *TrieDB) newRevision(root common.Hash) (*ffi.Revision, error) {
+	revision, err := t.Firewood.Revision(ffi.Hash(root))
+	if errors.Is(err, ffi.ErrRevisionNotFound) {
+		return nil, &trie.MissingNodeError{NodeHash: root}
+	}
+	return revision, err
+}
+
+var errNotProposable = errors.New("parent root is not proposable")
+
+// newProposal creates a new proposal from either a committable proposal or the
+// tip of the database. Returns an error wrapping [errNotProposable] otherwise.
 func (t *TrieDB) newProposal(parentRoot common.Hash, batchOps []ffi.BatchOp) (*ffi.Proposal, error) {
+	t.mu.RLock()
+	defer t.mu.RUnlock()
+
 	switch parent, foundProposal := t.committable.Get(parentRoot); {
 	case foundProposal:
 		return parent.Propose(batchOps)
 	case parentRoot == common.Hash(t.Firewood.Root()):
 		return t.Firewood.Propose(batchOps)
 	default:
-		return nil, fmt.Errorf("parent root %+x is not proposable", parentRoot)
+		return nil, fmt.Errorf("%w: %+x", errNotProposable, parentRoot)
 	}
 }
 
-// trieCommit considers the provided proposal as canonical.
-// Should be called on [state.Trie.Commit].
+var errProposalPending = errors.New("a proposal is already pending")
+
+// trieCommit considers the provided proposal as canonical, to be consumed by
+// the next call to [TrieDB.Update]. Should be called on [state.Trie.Commit].
 //
-// p MUST not be nil.
-func (t *TrieDB) trieCommit(p *ffi.Proposal) {
+// Returns an error wrapping [errProposalPending] if a previous proposal would
+// be lost. p MUST not be nil.
+func (t *TrieDB) trieCommit(p *ffi.Proposal) error {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	if t.pending != nil {
+		return fmt.Errorf("%w: root %s", errProposalPending, common.Hash(t.pending.Root()))
+	}
 	t.pending = p
+	return nil
 }
 
 // Scheme returns [rawdb.HashScheme] to identify the database.

--- a/vms/saevm/firewood/triedb_test.go
+++ b/vms/saevm/firewood/triedb_test.go
@@ -43,6 +43,9 @@ func newStateDB(t *testing.T, db state.Database, root common.Hash) *state.StateD
 
 	sdb, err := state.New(root, db, nil)
 	require.NoErrorf(t, err, "state.New(%s, %T)", root, db)
+	t.Cleanup(func() {
+		assert.NoErrorf(t, sdb.Error(), "%T.Error()", sdb)
+	})
 
 	return sdb
 }
@@ -592,4 +595,221 @@ func TestUnknownCommitNoError(t *testing.T) {
 	db := newDB(t)
 	root := common.Hash{0x1}
 	require.NoErrorf(t, db.TrieDB().Commit(root, false), "triedb.Commit(%s)", root)
+}
+
+var (
+	addr1 = common.Address{1}
+	addr2 = common.Address{2}
+	addr3 = common.Address{3}
+)
+
+// TestCommitOnlyOneOfTwoProposals verifies that when two StateDBs branch from
+// the same parent, only the first is accepted by the TrieDB.
+func TestCommitOnlyOneOfTwoProposals(t *testing.T) {
+	db := newDB(t)
+	tip := types.EmptyRootHash
+
+	a := newStateDB(t, db, tip)
+	b := newStateDB(t, db, tip)
+	a.SetNonce(addr1, 1)
+	b.SetNonce(addr2, 1)
+	rootA := a.IntermediateRoot(true)
+	rootB := b.IntermediateRoot(true)
+	require.NotEqual(t, rootA, rootB, "different changes yield different roots")
+
+	got, err := a.Commit(1, true)
+	require.NoError(t, err, "a.Commit()")
+	require.Equal(t, rootA, got, "a.Commit() root")
+
+	// b's proposal was valid when hashed, but the TrieDB rejects a second
+	// proposal on the same parent.
+	_, err = b.Commit(1, true)
+	require.ErrorIs(t, err, errParentNotLatest, "b.Commit()")
+
+	tdb := db.TrieDB()
+	require.NoErrorf(t, tdb.Commit(rootA, false), "triedb.Commit(%s)", rootA)
+	require.NoErrorf(t, tdb.Commit(rootB, false), "triedb.Commit(%s) of unknown root", rootB)
+
+	// We CANNOT guarantee that the rootB isn't available, since it depends on the GC.
+	_, err = db.OpenTrie(rootA)
+	require.NoErrorf(t, err, "db.OpenTrie(%s)", rootA)
+}
+
+// TestTrieCommitRejectsLostProposal verifies that a proposal handed to the
+// TrieDB by a failed commit is not silently overwritten by a later one.
+func TestTrieCommitRejectsLostProposal(t *testing.T) {
+	db := newDB(t)
+	tdb := db.TrieDB()
+	tip := types.EmptyRootHash
+
+	a := newStateDB(t, db, tip)
+	b := newStateDB(t, db, tip)
+	a.SetNonce(addr1, 1)
+	b.SetNonce(addr2, 1)
+	b.IntermediateRoot(true) // proposal created while the parent is still the tip
+	rootA, err := a.Commit(1, true)
+	require.NoError(t, err, "a.Commit()")
+	require.NoErrorf(t, tdb.Commit(rootA, false), "triedb.Commit(%s)", rootA)
+
+	// b's proposal is handed to the TrieDB before [TrieDB.Update] rejects it,
+	// so it remains pending.
+	_, err = b.Commit(1, true)
+	require.ErrorIs(t, err, errParentNotLatest, "b.Commit()")
+
+	c := newStateDB(t, db, rootA)
+	c.SetNonce(addr3, 1)
+	_, err = c.Commit(2, true)
+	require.ErrorIs(t, err, errProposalPending, "c.Commit() while b's proposal is pending")
+}
+
+// TestProposalToReconstruction creates a proposal that ends up being
+// uncommittable. To allow hashing again, it replaces the proposal with a
+// reconstruction internally.
+func TestProposalToReconstruction(t *testing.T) {
+	db := newDB(t)
+	tip := types.EmptyRootHash
+
+	a := newStateDB(t, db, tip)
+	b := newStateDB(t, db, tip)
+	a.SetNonce(addr1, 1)
+	b.SetNonce(addr2, 1)
+	b.IntermediateRoot(true) // creates proposal
+
+	// Reference for b's eventual state, proposed while tip is still proposable.
+	want := newStateDB(t, db, tip)
+	want.SetNonce(addr2, 1)
+	want.SetNonce(addr3, 1)
+	wantRoot := want.IntermediateRoot(true)
+
+	rootA, err := a.Commit(1, true)
+	require.NoError(t, err, "a.Commit()")
+	require.NoErrorf(t, db.TrieDB().Commit(rootA, false), "triedb.Commit(%s)", rootA)
+
+	// b should now match want
+	// Hashing must now create a reconstruction instead of a proposal.
+	b.SetNonce(addr3, 1)
+	require.Equal(t, wantRoot, b.IntermediateRoot(true), "root via reconstruction")
+	require.Equal(t, uint64(1), b.GetNonce(addr3), "GetNonce() after reconstruction")
+
+	_, err = b.Commit(1, true)
+	require.ErrorIs(t, err, errHistoricalNotCommittable, "b.Commit()")
+}
+
+// TestReconstructionFromHistoricalRevision verifies that a StateDB opened at a
+// historical root can be repeatedly modified and hashed but never committed.
+func TestReconstructionFromHistoricalRevision(t *testing.T) {
+	db := newDB(t)
+	tdb := db.TrieDB()
+
+	blk1 := newStateDB(t, db, types.EmptyRootHash)
+	blk1.SetNonce(addr1, 1)
+	root1, err := blk1.Commit(1, true)
+	require.NoError(t, err, "blk1.Commit()")
+	require.NoErrorf(t, tdb.Commit(root1, false), "triedb.Commit(%s)", root1)
+
+	// Reference for the final state, proposed while root1 is still the tip.
+	addrs := []common.Address{{0xa}, {0xb}, {0xc}}
+	want := newStateDB(t, db, root1)
+	for _, addr := range addrs {
+		want.SetNonce(addr, 1)
+	}
+	wantRoot := want.IntermediateRoot(true)
+
+	blk2 := newStateDB(t, db, root1)
+	blk2.SetNonce(addr2, 1)
+	root2, err := blk2.Commit(2, true)
+	require.NoError(t, err, "blk2.Commit()")
+	require.NoErrorf(t, tdb.Commit(root2, false), "triedb.Commit(%s)", root2)
+
+	sdb := newStateDB(t, db, root1)
+	require.Equal(t, root1, sdb.IntermediateRoot(true), "IntermediateRoot() without changes")
+	require.Equal(t, uint64(0), sdb.GetNonce(addr2), "block 2 is not visible at root1")
+
+	prev := root1
+	for i, addr := range addrs {
+		sdb.SetNonce(addr, 1)
+		root := sdb.IntermediateRoot(true)
+		require.NotEqual(t, prev, root, "IntermediateRoot() after change %d", i)
+		prev = root
+	}
+	require.Equal(t, wantRoot, prev, "final root matches the proposal reference")
+	require.Equal(t, prev, sdb.IntermediateRoot(true), "IntermediateRoot() without new changes")
+
+	_, err = sdb.Commit(2, true)
+	require.ErrorIs(t, err, errHistoricalNotCommittable, "Commit()")
+}
+
+// TestCopyDoesNotAliasProposal verifies that a copy of a proposal-backed
+// StateDB hashes independently and survives the original being committed.
+func TestCopyDoesNotAliasProposal(t *testing.T) {
+	db := newDB(t)
+	tdb := db.TrieDB()
+
+	base := newStateDB(t, db, types.EmptyRootHash)
+	base.SetNonce(addr1, 1)
+	tip, err := base.Commit(1, true)
+	require.NoError(t, err, "base.Commit()")
+	require.NoErrorf(t, tdb.Commit(tip, false), "triedb.Commit(%s)", tip)
+
+	a := newStateDB(t, db, tip)
+	a.SetNonce(addr1, 2)
+	rootA := a.IntermediateRoot(true)
+
+	cp := a.Copy()
+	require.Equal(t, rootA, cp.IntermediateRoot(true), "copy hashes to the same root")
+
+	_, err = a.Commit(2, true)
+	require.NoError(t, err, "a.Commit()")
+	require.NoErrorf(t, tdb.Commit(rootA, false), "triedb.Commit(%s)", rootA)
+	require.Equal(t, uint64(2), cp.GetNonce(addr1), "GetNonce() on copy after original committed")
+	require.Equal(t, rootA, cp.IntermediateRoot(true), "IntermediateRoot() on copy after original committed")
+
+	// The copy holds its own proposal on tip, which is no longer the latest
+	// root, so it is rejected rather than treated as the original's proposal.
+	_, err = cp.Commit(2, true)
+	require.ErrorIs(t, err, errParentNotLatest, "cp.Commit()")
+}
+
+// TestCopyClonesReconstruction verifies that a copy of a reconstruction-backed
+// StateDB diverges independently of the original.
+func TestCopyClonesReconstruction(t *testing.T) {
+	db := newDB(t)
+	tdb := db.TrieDB()
+
+	blk1 := newStateDB(t, db, types.EmptyRootHash)
+	blk1.SetNonce(addr1, 1)
+	root1, err := blk1.Commit(1, true)
+	require.NoError(t, err, "blk1.Commit()")
+	require.NoErrorf(t, tdb.Commit(root1, false), "triedb.Commit(%s)", root1)
+
+	// References for both divergent states, proposed while root1 is the tip.
+	wantX := newStateDB(t, db, root1)
+	wantX.SetNonce(addr1, 2)
+	wantX.SetNonce(addr2, 1)
+	wantRootX := wantX.IntermediateRoot(true)
+	wantY := newStateDB(t, db, root1)
+	wantY.SetNonce(addr1, 2)
+	wantY.SetNonce(addr3, 1)
+	wantRootY := wantY.IntermediateRoot(true)
+
+	blk2 := newStateDB(t, db, root1)
+	blk2.SetNonce(addr2, 5)
+	root2, err := blk2.Commit(2, true)
+	require.NoError(t, err, "blk2.Commit()")
+	require.NoErrorf(t, tdb.Commit(root2, false), "triedb.Commit(%s)", root2)
+
+	sdb := newStateDB(t, db, root1)
+	sdb.SetNonce(addr1, 2)
+	sdb.IntermediateRoot(true) // reconstruction is created here
+
+	cp := sdb.Copy()
+	sdb.SetNonce(addr2, 1)
+	cp.SetNonce(addr3, 1)
+	require.Equal(t, wantRootX, sdb.IntermediateRoot(true), "original root after divergence")
+	require.Equal(t, wantRootY, cp.IntermediateRoot(true), "copy root after divergence")
+
+	_, err = sdb.Commit(2, true)
+	require.ErrorIs(t, err, errHistoricalNotCommittable, "original Commit()")
+	_, err = cp.Commit(2, true)
+	require.ErrorIs(t, err, errHistoricalNotCommittable, "copy Commit()")
 }

--- a/vms/saevm/firewood/triedb_test.go
+++ b/vms/saevm/firewood/triedb_test.go
@@ -813,3 +813,38 @@ func TestCopyClonesReconstruction(t *testing.T) {
 	_, err = cp.Commit(2, true)
 	require.ErrorIs(t, err, errHistoricalNotCommittable, "copy Commit()")
 }
+
+// TestHashAfterTipMovesPastParent verifies that a trie whose parent stops being
+// proposable still hashes, which needs its revision handle re-taken.
+func TestHashAfterTipMovesPastParent(t *testing.T) {
+	db := newDB(t)
+	tdb := db.TrieDB()
+
+	blk1 := newStateDB(t, db, types.EmptyRootHash)
+	blk1.SetNonce(addr1, 1)
+	root1, err := blk1.Commit(1, true)
+	require.NoError(t, err, "blk1.Commit()")
+
+	// Opened while root1 is still an unpersisted proposal.
+	sdb := newStateDB(t, db, root1)
+	sdb.SetNonce(addr2, 1)
+	require.NotEqual(t, common.Hash{}, sdb.IntermediateRoot(true), "first root")
+
+	// Persist root1 and then move the tip past it, which makes root1
+	// unproposable and forces the reconstruction fallback.
+	require.NoErrorf(t, tdb.Commit(root1, false), "triedb.Commit(%s)", root1)
+	blk2 := newStateDB(t, db, root1)
+	blk2.SetNonce(addr3, 1)
+	root2, err := blk2.Commit(2, true)
+	require.NoError(t, err, "blk2.Commit()")
+	require.NoErrorf(t, tdb.Commit(root2, false), "triedb.Commit(%s)", root2)
+
+	sdb.SetNonce(addr2, 2)
+	got := sdb.IntermediateRoot(true)
+	require.NotEqual(t, common.Hash{}, got, "root after the tip moved past the parent")
+	require.NoError(t, sdb.Error(), "StateDB.Error()")
+
+	want := newStateDB(t, db, root1)
+	want.SetNonce(addr2, 2)
+	require.Equal(t, want.IntermediateRoot(true), got, "root matches a freshly opened trie")
+}

--- a/vms/saevm/firewood/triedb_test.go
+++ b/vms/saevm/firewood/triedb_test.go
@@ -50,6 +50,34 @@ func newStateDB(t *testing.T, db state.Database, root common.Hash) *state.StateD
 	return sdb
 }
 
+// A backend is a stateful wrapper around a statedb.
+type backend struct {
+	db  state.Database
+	sdb *state.StateDB
+}
+
+func newBackend(t *testing.T, db state.Database) *backend {
+	return &backend{
+		db:  db,
+		sdb: newStateDB(t, db, types.EmptyRootHash),
+	}
+}
+
+// commit ends the current block, reopens a fresh StateDB at the new root and
+// returns that root.
+func (b *backend) commit(t *testing.T, blockNum uint64) common.Hash {
+	t.Helper()
+	root, err := b.sdb.Commit(blockNum, true /* EIP-158 */)
+	require.NoErrorf(t, err, "%T.Commit()", b.sdb)
+	b.sdb = newStateDB(t, b.db, root)
+	return root
+}
+
+// copy replaces the statedb with a copy of itself.
+func (b *backend) copy() {
+	b.sdb = b.sdb.Copy()
+}
+
 // account is the in-memory reference for a single account.
 type account struct {
 	nonce       uint64
@@ -60,8 +88,7 @@ type account struct {
 type SUT struct {
 	r *reader
 
-	fwDB, hashDB       state.Database
-	fwState, hashState *state.StateDB
+	want, got *backend
 
 	lastRoot common.Hash
 	blockNum uint64
@@ -75,20 +102,12 @@ type SUT struct {
 	destructedThisTx set.Set[common.Address] // eligible for resurrection
 }
 
-func newSUT(t *testing.T, r *reader) *SUT {
-	fwDB := newDB(t)
-	hashDB := state.NewDatabase(rawdb.NewMemoryDatabase())
-
-	root := types.EmptyRootHash
-	fwState := newStateDB(t, fwDB, root)
-	hashState := newStateDB(t, hashDB, root)
+func newSUT(r *reader, want, got *backend) *SUT {
 	return &SUT{
 		r:                r,
-		fwDB:             fwDB,
-		fwState:          fwState,
-		hashDB:           hashDB,
-		hashState:        hashState,
-		lastRoot:         root,
+		want:             want,
+		got:              got,
+		lastRoot:         types.EmptyRootHash,
 		accounts:         make(map[common.Address]*account),
 		createdThisTx:    set.NewSet[common.Address](0),
 		destructedThisTx: set.NewSet[common.Address](0),
@@ -136,8 +155,8 @@ func (s *SUT) createAccount(t *testing.T) {
 	s.addrs = append(s.addrs, addr)
 	s.createdThisTx.Add(addr)
 
-	s.fwState.CreateAccount(addr)
-	s.hashState.CreateAccount(addr)
+	s.want.sdb.CreateAccount(addr)
+	s.got.sdb.CreateAccount(addr)
 }
 
 // Reads 1 byte from the reader
@@ -153,10 +172,10 @@ func (s *SUT) updateAccount(t *testing.T) {
 	acc.nonce++
 	acc.balance = new(uint256.Int).Add(acc.balance, uint256.NewInt(1))
 
-	s.fwState.SetNonce(addr, acc.nonce)
-	s.fwState.SetBalance(addr, acc.balance)
-	s.hashState.SetNonce(addr, acc.nonce)
-	s.hashState.SetBalance(addr, acc.balance)
+	s.want.sdb.SetNonce(addr, acc.nonce)
+	s.want.sdb.SetBalance(addr, acc.balance)
+	s.got.sdb.SetNonce(addr, acc.nonce)
+	s.got.sdb.SetBalance(addr, acc.balance)
 }
 
 // selfDestruct6780 models the SELFDESTRUCT opcode under EIP-6780.
@@ -176,8 +195,8 @@ func (s *SUT) selfDestruct6780() {
 	i := int(param) % len(s.addrs)
 	addr := s.addrs[i]
 
-	s.fwState.Selfdestruct6780(addr)
-	s.hashState.Selfdestruct6780(addr)
+	s.want.sdb.Selfdestruct6780(addr)
+	s.got.sdb.Selfdestruct6780(addr)
 
 	if !s.createdThisTx.Contains(addr) {
 		return // not created this tx: Selfdestruct6780 is a no-op
@@ -203,13 +222,12 @@ func (s *SUT) setStorage(t *testing.T) {
 	acc := s.accounts[addr]
 	acc.activeSlots = append(acc.activeSlots, key)
 
-	s.fwState.SetState(addr, key, val)
-	s.hashState.SetState(addr, key, val)
-
 	// To prevent cyclical roots (A -> B -> A), update nonce
 	acc.nonce++
-	s.fwState.SetNonce(addr, acc.nonce)
-	s.hashState.SetNonce(addr, acc.nonce)
+	s.want.sdb.SetState(addr, key, val)
+	s.want.sdb.SetNonce(addr, acc.nonce)
+	s.got.sdb.SetState(addr, key, val)
+	s.got.sdb.SetNonce(addr, acc.nonce)
 }
 
 // Reads 1 byte from the reader to select account and key
@@ -227,13 +245,12 @@ func (s *SUT) deleteStorage() {
 	key := acc.activeSlots[i]
 	acc.activeSlots = utils.DeleteIndex(acc.activeSlots, i)
 
-	s.fwState.SetState(addr, key, common.Hash{})
-	s.hashState.SetState(addr, key, common.Hash{})
-
 	// To prevent cyclical roots (A -> B -> A), update nonce
 	acc.nonce++
-	s.fwState.SetNonce(addr, acc.nonce)
-	s.hashState.SetNonce(addr, acc.nonce)
+	s.want.sdb.SetState(addr, key, common.Hash{})
+	s.want.sdb.SetNonce(addr, acc.nonce)
+	s.got.sdb.SetState(addr, key, common.Hash{})
+	s.got.sdb.SetNonce(addr, acc.nonce)
 }
 
 // Reads 2 bytes from the reader to select account and key
@@ -243,17 +260,17 @@ func (s *SUT) read(t *testing.T) {
 	}
 
 	addr := s.selectAddr(s.r.byte())
-	require.Equal(t, s.hashState.GetNonce(addr), s.fwState.GetNonce(addr), "nonce mismatch for %s", addr)
-	require.Equal(t, s.hashState.Exist(addr), s.fwState.Exist(addr), "existence mismatch for %s", addr)
-	require.Equal(t, s.hashState.Empty(addr), s.fwState.Empty(addr), "emptiness mismatch for %s", addr)
-	require.Equal(t, s.hashState.GetBalance(addr), s.fwState.GetBalance(addr), "balance mismatch for %s", addr)
-	require.Equal(t, s.hashState.GetNonce(addr), s.fwState.GetNonce(addr), "nonce mismatch for %s", addr)
+	want, got := s.want.sdb, s.got.sdb
+	require.Equal(t, want.GetNonce(addr), got.GetNonce(addr), "nonce mismatch for %s", addr)
+	require.Equal(t, want.Exist(addr), got.Exist(addr), "existence mismatch for %s", addr)
+	require.Equal(t, want.Empty(addr), got.Empty(addr), "emptiness mismatch for %s", addr)
+	require.Equal(t, want.GetBalance(addr), got.GetBalance(addr), "balance mismatch for %s", addr)
 	// [state.StateDB.GetStorageRoot] is known not to produce compatible
 	// outputs.
-	require.Equal(t, s.hashState.GetCode(addr), s.fwState.GetCode(addr), "code mismatch for %s", addr)
-	require.Equal(t, s.hashState.GetCodeSize(addr), s.fwState.GetCodeSize(addr), "code size mismatch for %s", addr)
-	require.Equal(t, s.hashState.GetCodeHash(addr), s.fwState.GetCodeHash(addr), "code hash mismatch for %s", addr)
-	require.Equal(t, s.hashState.HasSelfDestructed(addr), s.fwState.HasSelfDestructed(addr), "self-destruct mismatch for %s", addr)
+	require.Equal(t, want.GetCode(addr), got.GetCode(addr), "code mismatch for %s", addr)
+	require.Equal(t, want.GetCodeSize(addr), got.GetCodeSize(addr), "code size mismatch for %s", addr)
+	require.Equal(t, want.GetCodeHash(addr), got.GetCodeHash(addr), "code hash mismatch for %s", addr)
+	require.Equal(t, want.HasSelfDestructed(addr), got.HasSelfDestructed(addr), "self-destruct mismatch for %s", addr)
 
 	storage := s.accounts[addr].activeSlots
 	if len(storage) == 0 {
@@ -262,16 +279,8 @@ func (s *SUT) read(t *testing.T) {
 	i := int(s.r.byte()) % len(storage)
 	key := storage[i]
 
-	require.Equal(t,
-		s.hashState.GetState(addr, key),
-		s.fwState.GetState(addr, key),
-		"storage mismatch for %s[%s]", addr, key,
-	)
-	require.Equal(t,
-		s.hashState.GetCommittedState(addr, key),
-		s.fwState.GetCommittedState(addr, key),
-		"committed storage mismatch for %s[%s]", addr, key,
-	)
+	require.Equal(t, want.GetState(addr, key), got.GetState(addr, key), "storage mismatch for %s[%s]", addr, key)
+	require.Equal(t, want.GetCommittedState(addr, key), got.GetCommittedState(addr, key), "committed storage mismatch for %s[%s]", addr, key)
 }
 
 // finaliseTx resets the model's per-transaction tracking to mirror
@@ -284,36 +293,32 @@ func (s *SUT) finaliseTx() {
 }
 
 func (s *SUT) finalise() {
-	s.fwState.Finalise(true /* EIP-158 */)
-	s.hashState.Finalise(true /* EIP-158 */)
+	s.want.sdb.Finalise(true /* EIP-158 */)
+	s.got.sdb.Finalise(true /* EIP-158 */)
 	s.finaliseTx()
 }
 
 func (s *SUT) intermediateRoot(t *testing.T) {
-	fwRoot := s.fwState.IntermediateRoot(true /* EIP-158 */)
-	hashRoot := s.hashState.IntermediateRoot(true /* EIP-158 */)
-	require.Equal(t, hashRoot, fwRoot, "root mismatch")
+	want := s.want.sdb.IntermediateRoot(true /* EIP-158 */)
+	got := s.got.sdb.IntermediateRoot(true /* EIP-158 */)
+	require.Equal(t, want, got, "root mismatch")
 	s.finaliseTx() // IntermediateRoot calls Finalise
 }
 
 func (s *SUT) stateDBCommit(t *testing.T) {
-	hashRoot, err := s.hashState.Commit(s.blockNum, true /* EIP-158 */)
-	require.NoError(t, err, "hashState.Commit()")
-	fwRoot, err := s.fwState.Commit(s.blockNum, true /* EIP-158 */)
-	require.NoError(t, err, "fwState.Commit()")
-	require.Equal(t, hashRoot, fwRoot, "root mismatch after commit")
+	want := s.want.commit(t, s.blockNum)
+	got := s.got.commit(t, s.blockNum)
+	require.Equal(t, want, got, "root mismatch after commit")
 
-	s.lastRoot = fwRoot
+	s.lastRoot = want
 	s.blockNum++
-
-	s.fwState = newStateDB(t, s.fwDB, s.lastRoot)
-	s.hashState = newStateDB(t, s.hashDB, s.lastRoot)
 	s.finaliseTx() // Commit calls Finalise
 }
 
 func (s *SUT) diskCommit(t *testing.T) {
-	require.NoErrorf(t, s.fwDB.TrieDB().Commit(s.lastRoot, false), "triedb.Commit(%s)", s.lastRoot)
-	require.NoErrorf(t, s.hashDB.TrieDB().Commit(s.lastRoot, false), "triedb.Commit(%s)", s.lastRoot)
+	want, got := s.want.db, s.got.db
+	require.NoErrorf(t, want.TrieDB().Commit(s.lastRoot, false), "%T.TrieDB().Commit(%s)", want, s.lastRoot)
+	require.NoErrorf(t, got.TrieDB().Commit(s.lastRoot, false), "%T.TrieDB().Commit(%s)", got, s.lastRoot)
 }
 
 func (s *SUT) copyStateDB() {
@@ -322,8 +327,8 @@ func (s *SUT) copyStateDB() {
 	// storage) are lost, so the account will NOT be deleted as expected.
 	s.finalise()
 
-	s.fwState = s.fwState.Copy()
-	s.hashState = s.hashState.Copy()
+	s.want.copy()
+	s.got.copy()
 }
 
 // TODO(#5539): support [*state.StateDB.SelfDestruct]
@@ -418,7 +423,10 @@ func FuzzStateRoot(f *testing.F) {
 
 	f.Fuzz(func(t *testing.T, stream []byte) {
 		r := &reader{stream: stream}
-		sut := newSUT(t, r)
+		sut := newSUT(r,
+			newBackend(t, state.NewDatabase(rawdb.NewMemoryDatabase())), // hashdb
+			newBackend(t, newDB(t)), // firewood
+		)
 		for !r.empty() {
 			switch r.op() {
 			case opCreateAccount:
@@ -451,6 +459,106 @@ func FuzzStateRoot(f *testing.F) {
 			case opDiskCommit:
 				t.Log("disk commit (previous block)")
 				sut.diskCommit(t)
+			case opCopyStateDB:
+				t.Log("copy StateDB")
+				sut.copyStateDB()
+			}
+		}
+		sut.intermediateRoot(t) // final flush to tries and verify all pending state
+	})
+}
+
+// newReconstructedBackend returns a Firewood backend whose StateDB is opened at
+// the empty root after the tip has moved past it. One MUST NOT call
+// [state.StateDB.Commit] or [triedb.Database.Commit] on it, as these are not
+// eligible operations.
+func newReconstructedBackend(t *testing.T) *backend {
+	db := newDB(t)
+
+	// The sdb address is never generated by the model
+	sdb := newStateDB(t, db, types.EmptyRootHash)
+	sdb.SetNonce(common.Address{0xff}, 1)
+	fillerRoot, err := sdb.Commit(0, true /* EIP-158 */)
+	require.NoError(t, err, "filler Commit()")
+	require.NoErrorf(t, db.TrieDB().Commit(fillerRoot, false), "triedb.Commit(%s)", fillerRoot)
+
+	return newBackend(t, db)
+}
+
+func FuzzReconstructedRoot(f *testing.F) {
+	tests := [][]byte{
+		{
+			opCreateAccount, 0,
+			opUpdateAccount, 0,
+			opSetStorage, 0, 1, 2,
+			opRead, 0, 0,
+		},
+		{
+			opCreateAccount, 0,
+			opSetStorage, 0, 1, 2,
+			opIntermediateRoot,
+			opDeleteStorage, 0 /*acct*/, 0, /*idx*/
+			opRead, 0, 0,
+		},
+		{
+			opCreateAccount, 0,
+			opUpdateAccount, 0,
+			opFinalise,
+			opSelfDestruct6780, 0,
+		},
+		{
+			opCreateAccount, 0,
+			opSetStorage, 0, 1, 2,
+			opSelfDestruct6780, 0,
+			opCreateAccount, 1, // resurrects the just-destructed account
+			opSetStorage, 0, 3, 4,
+			opIntermediateRoot,
+			opRead, 0, 0,
+		},
+		{
+			opCreateAccount, 0,
+			opUpdateAccount, 0,
+			opIntermediateRoot,
+			opCopyStateDB,
+			opSetStorage, 0, 1, 2,
+			opIntermediateRoot,
+		},
+	}
+	for _, test := range tests {
+		f.Add(test)
+	}
+
+	f.Fuzz(func(t *testing.T, stream []byte) {
+		r := &reader{stream: stream}
+		sut := newSUT(r, newBackend(t, newDB(t)), newReconstructedBackend(t))
+		for !r.empty() {
+			// [state.StateDB.Commit] andn [triedb.Database.Commit] are not valid
+			// options for a reconstructed state, and aren't included below.
+			switch r.op() {
+			case opCreateAccount:
+				t.Log("create account")
+				sut.createAccount(t)
+			case opUpdateAccount:
+				t.Log("update account")
+				sut.updateAccount(t)
+			case opSelfDestruct6780:
+				t.Log("delete account")
+				sut.selfDestruct6780()
+			case opSetStorage:
+				t.Log("set storage")
+				sut.setStorage(t)
+			case opDeleteStorage:
+				t.Log("delete storage")
+				sut.deleteStorage()
+			case opRead:
+				t.Log("read")
+				sut.read(t)
+			case opFinalise:
+				t.Log("finalise (end transaction)")
+				sut.finalise()
+			case opIntermediateRoot:
+				t.Log("intermediate root (end transaction)")
+				sut.intermediateRoot(t)
 			case opCopyStateDB:
 				t.Log("copy StateDB")
 				sut.copyStateDB()

--- a/vms/saevm/sae/rpc/BUILD.bazel
+++ b/vms/saevm/sae/rpc/BUILD.bazel
@@ -61,6 +61,7 @@ go_library(
         "@com_github_ava_labs_libevm//params",
         "@com_github_ava_labs_libevm//rlp",
         "@com_github_ava_labs_libevm//rpc",
+        "@com_github_ava_labs_libevm//trie",
         "@org_uber_go_zap//:zap",
     ],
 )

--- a/vms/saevm/sae/rpc/stateful.go
+++ b/vms/saevm/sae/rpc/stateful.go
@@ -154,6 +154,20 @@ func (b *backend) stateAtBlock(ctx context.Context, num uint64) (*state.StateDB,
 		parent = stored // The stored block is marked as executed.
 	}
 
+	// TODO(alarso16): Hashing is an expensive operation and is only used here
+	// to check if there was an error during re-execution. Add metrics to
+	// determine whether this check is prohibitively expensive.
+	got := sdb.IntermediateRoot(true)
+	want := parent.PostExecutionStateRoot()
+	if got != want {
+		return nil, nil, fmt.Errorf(
+			"incorrect state root on reconstruction: block %d produced %s, want %s",
+			parent.NumberU64(),
+			got,
+			want,
+		)
+	}
+
 	return sdb, parent, nil
 }
 

--- a/vms/saevm/sae/rpc/stateful.go
+++ b/vms/saevm/sae/rpc/stateful.go
@@ -126,6 +126,10 @@ func (b *backend) stateAtBlock(ctx context.Context, num uint64) (*state.StateDB,
 	}
 
 	for _, stored := range toReexec {
+		if ctx.Err() != nil {
+			return nil, nil, context.Cause(ctx)
+		}
+
 		// A settled block has no ancestry, which [saexec.Execute] requires,
 		// so it is rebuilt on top of the previous block.
 		bl, err := b.NewBlock(stored.EthBlock(), parent, nil)
@@ -139,7 +143,6 @@ func (b *backend) stateAtBlock(ctx context.Context, num uint64) (*state.StateDB,
 			b.ChainConfig(),
 			b.ChainContext(),
 			b.Logger(),
-			saexec.SkipEndOfBlockOps(),
 		)
 		if err != nil {
 			return nil, nil, fmt.Errorf("re-executing block %d: %w", stored.NumberU64(), err)
@@ -147,12 +150,11 @@ func (b *backend) stateAtBlock(ctx context.Context, num uint64) (*state.StateDB,
 
 		// A normal execution would commit this state or store it in the triedb.
 		sdb.Finalise(true)
-		// The stored block carries the executed gas clock that the next block's
-		// execution reads from its parent.
-		parent = stored
+
+		parent = stored // The stored block is marked as executed.
 	}
 
-	return sdb.Copy(), parent, nil
+	return sdb, parent, nil
 }
 
 // lastBlockWithState searches backwards from block num for the most recent
@@ -163,10 +165,13 @@ func (b *backend) lastBlockWithState(ctx context.Context, num uint64) (*state.St
 	const maxReexec = 8192 // TODO(alarso16): determine using commit interval and settlement height
 
 	var (
-		toReexec     []*blocks.Block
-		notFoundType = new(trie.MissingNodeError)
+		toReexec    []*blocks.Block
+		errNotFound = new(trie.MissingNodeError)
 	)
 	for i := range uint64(maxReexec) {
+		if ctx.Err() != nil {
+			return nil, nil, nil, context.Cause(ctx)
+		}
 		if num < i {
 			break
 		}
@@ -177,7 +182,7 @@ func (b *backend) lastBlockWithState(ctx context.Context, num uint64) (*state.St
 		}
 		sdb, err := b.StateDB(bl.PostExecutionStateRoot())
 		switch {
-		case errors.As(err, &notFoundType):
+		case errors.As(err, &errNotFound):
 			toReexec = append(toReexec, bl)
 			continue
 		case err != nil:

--- a/vms/saevm/sae/rpc/stateful.go
+++ b/vms/saevm/sae/rpc/stateful.go
@@ -8,6 +8,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"slices"
 	"time"
 
 	"github.com/ava-labs/libevm/common"
@@ -22,6 +23,7 @@ import (
 	"github.com/ava-labs/libevm/libevm/ethapi"
 	"github.com/ava-labs/libevm/rlp"
 	"github.com/ava-labs/libevm/rpc"
+	"github.com/ava-labs/libevm/trie"
 	"go.uber.org/zap"
 
 	"github.com/ava-labs/avalanchego/vms/saevm/blocks"
@@ -85,12 +87,12 @@ func (b *backend) StateAndHeaderByNumberOrHash(ctx context.Context, numOrHash rp
 		return nil, nil, err
 	}
 
-	hdr := executedHeader(bl)
-	sdb, err := b.StateDB(hdr.Root)
+	sdb, _, err := b.stateAtBlock(ctx, bl.NumberU64())
 	if err != nil {
 		return nil, nil, err
 	}
-	return sdb, hdr, nil
+
+	return sdb, executedHeader(bl), nil
 }
 
 // StateAtBlock returns the state database after executing the given block.
@@ -117,17 +119,74 @@ func (b *backend) StateAtBlock(ctx context.Context, block *types.Block, reexec u
 // stateAtBlock returns the state after executing block num, along with the
 // stored block it was restored from.
 func (b *backend) stateAtBlock(ctx context.Context, num uint64) (*state.StateDB, *blocks.Block, error) {
-	n := rpc.BlockNumber(num) // #nosec G115 -- won't overflow for a while.
-	bl, err := b.restoreExecutedBlock(ctx, rpc.BlockNumberOrHashWithNumber(n))
+	sdb, parent, toReexec, err := b.lastBlockWithState(ctx, num)
 	if err != nil {
 		return nil, nil, err
 	}
 
-	sdb, err := b.StateDB(bl.PostExecutionStateRoot())
-	if err != nil {
-		return nil, nil, err
+	for _, stored := range toReexec {
+		// A settled block has no ancestry, which [saexec.Execute] requires,
+		// so it is rebuilt on top of the previous block.
+		bl, err := b.NewBlock(stored.EthBlock(), parent, nil)
+		if err != nil {
+			return nil, nil, fmt.Errorf("constructing SAE block %d: %w", stored.NumberU64(), err)
+		}
+		_, err = saexec.Execute(
+			bl,
+			sdb,
+			b.Hooks(),
+			b.ChainConfig(),
+			b.ChainContext(),
+			b.Logger(),
+			saexec.SkipEndOfBlockOps(),
+		)
+		if err != nil {
+			return nil, nil, fmt.Errorf("re-executing block %d: %w", stored.NumberU64(), err)
+		}
+
+		// A normal execution would commit this state or store it in the triedb.
+		sdb.Finalise(true /*EIP-151*/)
+		// The stored block carries the executed gas clock that the next block's
+		// execution reads from its parent.
+		parent = stored
 	}
-	return sdb, bl, nil
+
+	return sdb.Copy(), parent, nil
+}
+
+// lastBlockWithState searches backwards from block num for the most recent
+// block with available post-execution state. It returns that state and block,
+// along with the blocks (in ascending order, excluding the found block) that
+// must be re-executed on top of it to reach the state of block num.
+func (b *backend) lastBlockWithState(ctx context.Context, num uint64) (*state.StateDB, *blocks.Block, []*blocks.Block, error) {
+	const maxReexec = 8192 // TODO(alarso16): determine using commit interval and settlement height
+
+	var (
+		toReexec     []*blocks.Block
+		notFoundType = new(trie.MissingNodeError)
+	)
+	for i := range uint64(maxReexec) {
+		if num < i {
+			break
+		}
+		rpcNum := rpc.BlockNumber(num - i) // #nosec G115 -- won't overflow for a while.
+		bl, err := b.restoreExecutedBlock(ctx, rpc.BlockNumberOrHashWithNumber(rpcNum))
+		if err != nil {
+			return nil, nil, nil, err
+		}
+		sdb, err := b.StateDB(bl.PostExecutionStateRoot())
+		switch {
+		case errors.As(err, &notFoundType):
+			toReexec = append(toReexec, bl)
+			continue
+		case err != nil:
+			return nil, nil, nil, fmt.Errorf("unexpected error looking for state: %w", err)
+		}
+		slices.Reverse(toReexec)
+		return sdb, bl, toReexec, nil
+	}
+
+	return nil, nil, nil, fmt.Errorf("no parent state of block %d found", num)
 }
 
 // StateAtTransaction returns the execution environment of a particular
@@ -147,17 +206,13 @@ func (b *backend) StateAtTransaction(ctx context.Context, ethB *types.Block, txI
 		return nil, bCtx, nil, nil, fmt.Errorf("transaction index %d out of range [0, %d)", txIndex, len(txs))
 	}
 
-	parent, err := b.restoreExecutedParent(ctx, ethB)
+	stateDB, parent, err := b.stateAtBlock(ctx, ethB.NumberU64()-1)
 	if err != nil {
-		return nil, bCtx, nil, nil, fmt.Errorf("restoring parent block: %w", err)
+		return nil, bCtx, nil, nil, err
 	}
 	block, err := b.NewBlock(ethB, parent, nil)
 	if err != nil {
 		return nil, bCtx, nil, nil, fmt.Errorf("constructing SAE block: %v", err)
-	}
-	stateDB, err := b.StateDB(parent.PostExecutionStateRoot())
-	if err != nil {
-		return nil, bCtx, nil, nil, err
 	}
 
 	// Replay transactions 0..txIndex-1 to produce the state just before the

--- a/vms/saevm/sae/rpc/stateful.go
+++ b/vms/saevm/sae/rpc/stateful.go
@@ -98,7 +98,8 @@ func (b *backend) StateAndHeaderByNumberOrHash(ctx context.Context, numOrHash rp
 // StateAtBlock returns the state database after executing the given block.
 //
 // The reexec, base, readOnly, and preferDisk parameters are ignored because SAE
-// does not implement geth's re-execution-from-archive strategy.
+// does not implement geth's re-execution-from-archive strategy, but relies on
+// internal details.
 //
 // Like geth, SAE only stores historical state roots, not full historical state.
 // The underlying trie data must still be present in the state cache/DB for
@@ -145,7 +146,7 @@ func (b *backend) stateAtBlock(ctx context.Context, num uint64) (*state.StateDB,
 		}
 
 		// A normal execution would commit this state or store it in the triedb.
-		sdb.Finalise(true /*EIP-151*/)
+		sdb.Finalise(true)
 		// The stored block carries the executed gas clock that the next block's
 		// execution reads from its parent.
 		parent = stored

--- a/vms/saevm/sae/rpc_stateful_test.go
+++ b/vms/saevm/sae/rpc_stateful_test.go
@@ -36,9 +36,12 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/ava-labs/avalanchego/database/memdb"
 	"github.com/ava-labs/avalanchego/utils"
+	"github.com/ava-labs/avalanchego/utils/logging"
 	"github.com/ava-labs/avalanchego/vms/saevm/blocks"
 	"github.com/ava-labs/avalanchego/vms/saevm/cmputils"
+	"github.com/ava-labs/avalanchego/vms/saevm/saedb"
 	"github.com/ava-labs/avalanchego/vms/saevm/saetest"
 	"github.com/ava-labs/avalanchego/vms/saevm/saetest/escrow"
 
@@ -654,31 +657,86 @@ func TestDebugStandardTraceBlockToFile(t *testing.T) {
 // TestDebugIntermediateRoots verifies that debug_intermediateRoots returns one
 // root per transaction, the last of which is the block's post-execution root.
 func TestDebugIntermediateRoots(t *testing.T) {
-	ctx, sut := newSUT(t, 1)
+	const commitInterval = 4
 
-	const numTxs = 2
-	txs := make([]*types.Transaction, numTxs)
-	for i := range txs {
-		txs[i] = sut.wallet.SetNonceAndSign(t, 0, &types.LegacyTx{
-			To:       &common.Address{},
-			Gas:      params.TxGas,
-			GasPrice: big.NewInt(1),
-			Value:    big.NewInt(1),
+	tests := []struct {
+		name string
+		opts []sutOption
+	}{
+		{
+			name: "hashdb_archival",
+			opts: []sutOption{withArchival()},
+		},
+		{
+			name: "hashdb_pruning",
+			opts: []sutOption{withCommitInterval(commitInterval)},
+		},
+		{
+			name: "firewood_archival_every",
+			opts: []sutOption{withFirewood(), withArchival(), withCommitInterval(1)},
+		},
+		{
+			name: "firewood_archival_interval",
+			opts: []sutOption{withFirewood(), withArchival(), withCommitInterval(commitInterval)},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			const (
+				numBlocks   = 2*commitInterval + 3
+				txsPerBlock = 2
+			)
+
+			srcDB := memdb.New()
+			xdb := saetest.NewHeightIndexDB()
+			timeOpt, vmTime := withVMTime(t, time.Unix(saeparams.TauSeconds, 0))
+			dataDir := t.TempDir()
+			opts := append(slices.Clone(tt.opts), options.Func[sutConfig](func(c *sutConfig) {
+				c.dataDir = dataDir
+			}))
+			ctx, src := newSUT(t, 1, append(slices.Clone(opts), withDB(srcDB), withExecResultsDB(xdb), timeOpt)...)
+
+			blks := make([]*blocks.Block, 0, numBlocks)
+			for range numBlocks {
+				vmTime.AdvanceToSettle(ctx, t, src.lastAcceptedBlock(t))
+				txs := make([]*types.Transaction, txsPerBlock)
+				for i := range txs {
+					txs[i] = src.wallet.SetNonceAndSign(t, 0, &types.LegacyTx{
+						To:       &common.Address{},
+						Gas:      params.TxGas,
+						GasPrice: big.NewInt(1),
+						Value:    big.NewInt(1),
+					})
+				}
+				block := src.runConsensusLoop(t, txs...)
+				require.Lenf(t, block.Transactions(), len(txs), "%T.Transactions()", block)
+				blks = append(blks, block)
+			}
+
+			// restarting the VM clears the cache
+			src.close()
+			ctx, sut := newSUT(t, 1, append(slices.Clone(opts),
+				withDB(saetest.CopyDB(t, srcDB)),
+				withExecResultsDB(xdb.Clone()),
+			)...)
+
+			for _, block := range blks {
+				t.Run(fmt.Sprintf("block_%02d", block.NumberU64()), func(t *testing.T) {
+					var roots []common.Hash
+					require.NoError(t, sut.CallContext(ctx, &roots, "debug_intermediateRoots", block.Hash()), "CallContext(debug_intermediateRoots)")
+
+					require.Len(t, roots, txsPerBlock, "one root per transaction")
+					assert.NotEqual(t, roots[0], roots[1], "each transfer changes state (nonce and balances)")
+					// This holds only because nothing modifies state after the last tx:
+					// hookstest.Stub.FinishExecutingBlock is a no-op and there are no
+					// end-of-block ops. Hooks that mutate post-transaction state (e.g.
+					// the C-Chain's) would break this!!
+					assert.Equal(t, block.PostExecutionStateRoot(), roots[txsPerBlock-1], "last root is the block's post-execution root")
+				})
+			}
 		})
 	}
-	block := sut.runConsensusLoop(t, txs...)
-	require.Lenf(t, block.Transactions(), len(txs), "%T.Transactions()", block)
-
-	var roots []common.Hash
-	require.NoError(t, sut.CallContext(ctx, &roots, "debug_intermediateRoots", block.Hash()), "CallContext(debug_intermediateRoots)")
-
-	require.Len(t, roots, numTxs, "one root per transaction")
-	assert.NotEqual(t, roots[0], roots[1], "each transfer changes state (nonce and balances)")
-	// This holds only because nothing modifies state after the last tx:
-	// hookstest.Stub.FinishExecutingBlock is a no-op and there are no
-	// end-of-block ops. Hooks that mutate post-transaction state (e.g.
-	// the C-Chain's) would break this!!
-	assert.Equal(t, block.PostExecutionStateRoot(), roots[numTxs-1], "last root is the block's post-execution root")
 }
 
 func TestStatefulRPCs(t *testing.T) {
@@ -769,6 +827,99 @@ func TestStatefulRPCs(t *testing.T) {
 				assert.Equal(t, storageKeyHex, storage.Key, "GetProof().StorageProof[0].Key")
 				assert.Zerof(t, wantStorageValue.Cmp(storage.Value), "GetProof().StorageProof[0].Value: want %d, got %s", wantStorageValue, storage.Value)
 			})
+		})
+	}
+}
+
+// TestStatefulRPCsEveryHeight tests the stateful RPCs are available for all
+// block heights on multiple database configurations.
+func TestStatefulRPCsEveryHeight(t *testing.T) {
+	t.Parallel()
+
+	const (
+		commitInterval = 4
+		// Spans two commit boundaries, heights between them, and a tail of
+		// blocks that are not yet settled.
+		numBlocks = 2*commitInterval + 3
+	)
+
+	tests := []struct {
+		name string
+		opts []sutOption
+	}{
+		{
+			name: "hash_archival",
+			opts: []sutOption{withArchival(), withCommitInterval(saedb.DefaultCommitInterval)},
+		},
+		{
+			name: "hash_commit_every_block",
+			opts: []sutOption{withCommitInterval(1)},
+		},
+		{
+			name: "firewood_archival",
+			opts: []sutOption{withFirewood(), withArchival(), withCommitInterval(saedb.DefaultCommitInterval)},
+		},
+		{
+			name: "firewood_commit_every_block",
+			opts: []sutOption{withFirewood(), withArchival(), withCommitInterval(1)},
+		},
+		{
+			name: "firewood_commit_interval",
+			opts: []sutOption{withFirewood(), withArchival(), withCommitInterval(commitInterval)},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			srcDB := memdb.New()
+			srcHDB := saetest.NewHeightIndexDB()
+			dataDir := t.TempDir()
+			timeOpt, vmTime := withVMTime(t, time.Unix(saeparams.TauSeconds, 0))
+			dbOpts := append(slices.Clone(tt.opts),
+				timeOpt,
+				options.Func[sutConfig](func(c *sutConfig) {
+					c.dataDir = dataDir
+					c.logLevel = logging.Warn
+				}),
+			)
+
+			ctx, src := newSUT(t, 1, append(slices.Clone(dbOpts),
+				withExecResultsDB(srcHDB),
+				withDB(srcDB),
+			)...)
+
+			// One transfer per block, so the sender's nonce at height h is h.
+			prev := src.lastAcceptedBlock(t)
+			for h := uint64(1); h <= numBlocks; h++ {
+				// Settling the parent before building the next block evicts all
+				// but the most recent blocks from memory.
+				vmTime.AdvanceToSettle(ctx, t, prev)
+				b := src.runConsensusLoop(t, src.wallet.SetNonceAndSign(t, 0, &types.DynamicFeeTx{
+					To:        &zeroAddr,
+					Gas:       params.TxGas,
+					GasFeeCap: big.NewInt(params.GWei),
+				}))
+				require.NoErrorf(t, b.WaitUntilExecuted(ctx), "%T.WaitUntilExecuted()", b)
+				prev = b
+			}
+
+			sender := src.wallet.Addresses()[0]
+
+			// restarting the VM clears all caches
+			src.close()
+			ctx, sut := newSUT(t, 1, append(slices.Clone(dbOpts),
+				withExecResultsDB(srcHDB.Clone()),
+				withDB(saetest.CopyDB(t, srcDB)),
+			)...)
+
+			for height := uint64(1); height <= numBlocks; height++ {
+				t.Run(fmt.Sprintf("block_%02d", height), func(t *testing.T) {
+					got, err := sut.NonceAt(ctx, sender, new(big.Int).SetUint64(height))
+					require.NoError(t, err, "NonceAt()")
+					assert.Equal(t, height, got, "NonceAt(): one transaction per block")
+				})
+			}
 		})
 	}
 }

--- a/vms/saevm/sae/rpc_stateful_test.go
+++ b/vms/saevm/sae/rpc_stateful_test.go
@@ -913,7 +913,7 @@ func TestStatefulRPCsEveryHeight(t *testing.T) {
 				withDB(saetest.CopyDB(t, srcDB)),
 			)...)
 
-			for height := uint64(1); height <= numBlocks; height++ {
+			for height := range uint64(numBlocks) + 1 {
 				t.Run(fmt.Sprintf("block_%02d", height), func(t *testing.T) {
 					got, err := sut.NonceAt(ctx, sender, new(big.Int).SetUint64(height))
 					require.NoError(t, err, "NonceAt()")

--- a/vms/saevm/sae/rpc_stateful_test.go
+++ b/vms/saevm/sae/rpc_stateful_test.go
@@ -722,7 +722,7 @@ func TestDebugIntermediateRoots(t *testing.T) {
 			)...)
 
 			for _, block := range blks {
-				t.Run(fmt.Sprintf("block_%02d", block.NumberU64()), func(t *testing.T) {
+				t.Run(fmt.Sprintf("block_%d", block.NumberU64()), func(t *testing.T) {
 					var roots []common.Hash
 					require.NoError(t, sut.CallContext(ctx, &roots, "debug_intermediateRoots", block.Hash()), "CallContext(debug_intermediateRoots)")
 

--- a/vms/saevm/sae/vm_test.go
+++ b/vms/saevm/sae/vm_test.go
@@ -53,6 +53,7 @@ import (
 	"github.com/ava-labs/avalanchego/utils/set"
 	"github.com/ava-labs/avalanchego/utils/units"
 	"github.com/ava-labs/avalanchego/version"
+	"github.com/ava-labs/avalanchego/vms/evm/sync/customrawdb"
 	"github.com/ava-labs/avalanchego/vms/saevm/adaptor"
 	"github.com/ava-labs/avalanchego/vms/saevm/blocks"
 	"github.com/ava-labs/avalanchego/vms/saevm/blocks/blockstest"
@@ -306,9 +307,30 @@ func withExecResultsDB(hdb database.HeightIndex) sutOption {
 	})
 }
 
-func withCommitInterval(interval uint64) sutOption { //nolint:unparam // always 16 for now but caller-controlled by design
+func withCommitInterval(interval uint64) sutOption {
 	return options.Func[sutConfig](func(c *sutConfig) {
 		c.vmConfig.DBConfig.CommitInterval = interval
+	})
+}
+
+func withDB(db database.Database) sutOption {
+	return options.Func[sutConfig](func(c *sutConfig) {
+		c.db = db
+	})
+}
+
+// withFirewood selects Firewood as the trie database instead of the default
+// HashDB.
+func withFirewood() sutOption {
+	return options.Func[sutConfig](func(c *sutConfig) {
+		c.vmConfig.DBConfig.Scheme = customrawdb.FirewoodScheme
+	})
+}
+
+// withArchival disables pruning, persisting every executed state root.
+func withArchival() sutOption {
+	return options.Func[sutConfig](func(c *sutConfig) {
+		c.vmConfig.DBConfig.Archival = true
 	})
 }
 

--- a/vms/saevm/saedb/tracker.go
+++ b/vms/saevm/saedb/tracker.go
@@ -60,7 +60,7 @@ type Config struct {
 	Scheme            string // trie database scheme to use; defaults to [rawdb.HashScheme]
 	TrieCacheMiB      uint64 // size of the TrieDB cache
 	SnapshotCacheMiB  uint64 // size of the snapshot cache - if 0, snapshots are disabled
-	Archival          bool   // if true, will store every state on disk
+	Archival          bool   // if true, state will be persisted regularly for RPC support
 	CommitInterval    uint64 // MUST be set to a non-zero value
 	AllowMissingTries bool   // allow switching from archival to pruning on a DB that ran archival
 

--- a/vms/saevm/saedb/tracker.go
+++ b/vms/saevm/saedb/tracker.go
@@ -105,10 +105,6 @@ func (c Config) TrieDBConfig(dataDir string, log logging.Logger) *triedb.Config 
 			// Firewood doesn't allow memory-only operation
 			c.TrieCacheMiB = DefaultTrieCacheSizeMiB
 		}
-		if c.Archival {
-			// TODO(alarso16): Allow arbitrary values when re-execution is enabled
-			c.CommitInterval = 1
-		}
 		return &triedb.Config{
 			DBOverride: firewood.Config{
 				Path:                   filepath.Join(dataDir, graftfw.Directory),

--- a/vms/saevm/saedb/tracker.go
+++ b/vms/saevm/saedb/tracker.go
@@ -56,6 +56,8 @@ const (
 )
 
 // Config allows parameterization of the TrieDB and when state is committed.
+//
+// TODO(alarso16): completely separate HashDB and Firewood options.
 type Config struct {
 	Scheme            string // trie database scheme to use; defaults to [rawdb.HashScheme]
 	TrieCacheMiB      uint64 // size of the TrieDB cache

--- a/vms/saevm/saexec/saexec_test.go
+++ b/vms/saevm/saexec/saexec_test.go
@@ -1134,9 +1134,9 @@ func TestRecoveryStateAvailability(t *testing.T) {
 			scheme:   customrawdb.FirewoodScheme,
 			archival: true,
 			expectAvailable: func(height uint64) bool {
-				// All settled states MUST be available, as MUST the state
-				// committed at shutdown.
-				return height <= numBlocks
+				// Firewood is guaranteed to persist halfway to the commit interval.
+				// It MUST also have the most recent state.
+				return height%(commitInterval/2) == 0 || height == numBlocks
 			},
 		},
 		{

--- a/vms/saevm/saexec/saexec_test.go
+++ b/vms/saevm/saexec/saexec_test.go
@@ -1110,61 +1110,82 @@ func TestHashDBStateRootAvailability(t *testing.T) {
 // execute subsequent blocks.
 func TestRecoveryStateAvailability(t *testing.T) {
 	const (
-		commitInterval = 16
-		numBlocks      = commitInterval + 10
+		defaultCommitInterval = 16
+		numBlocks             = defaultCommitInterval + 10
+	)
+
+	type availability int
+	const (
+		available availability = iota + 1
+		unavailable
+		unknown
 	)
 
 	tests := []struct {
 		name            string
 		scheme          string
 		archival        bool
-		expectAvailable func(height uint64) bool
+		commitInterval  uint64
+		expectAvailable func(height uint64) availability
 	}{
 		{
-			name:     "hash_archival",
-			scheme:   rawdb.HashScheme,
-			archival: true,
-			expectAvailable: func(height uint64) bool {
+			name:           "hash_archival",
+			scheme:         rawdb.HashScheme,
+			archival:       true,
+			commitInterval: 1,
+			expectAvailable: func(height uint64) availability {
 				// All executed states MUST be available.
-				return height <= numBlocks
+				if height <= numBlocks {
+					return available
+				}
+				return unavailable
 			},
 		},
 		{
-			name:     "firewood_archival",
-			scheme:   customrawdb.FirewoodScheme,
-			archival: true,
-			expectAvailable: func(height uint64) bool {
-				// Firewood is guaranteed to persist halfway to the commit interval.
-				// It MUST also have the most recent state.
-				return height%(commitInterval/2) == 0 || height == numBlocks
+			name:           "firewood_archival",
+			scheme:         customrawdb.FirewoodScheme,
+			archival:       true,
+			commitInterval: defaultCommitInterval,
+			expectAvailable: func(height uint64) availability {
+				// The commitInterval is the MAXIMUM number of blocks before
+				// a state is persisted. The genesis is persisted separately.
+				if height == 0 || height == numBlocks {
+					return available
+				}
+				return unknown
 			},
 		},
 		{
-			name:     "firewood",
-			scheme:   customrawdb.FirewoodScheme,
-			archival: false,
-			expectAvailable: func(height uint64) bool {
+			name:           "firewood",
+			scheme:         customrawdb.FirewoodScheme,
+			archival:       false,
+			commitInterval: defaultCommitInterval,
+			expectAvailable: func(height uint64) availability {
 				// Only the state committed at shutdown should be available.
-				return height == numBlocks
+				if height == numBlocks {
+					return available
+				}
+				return unavailable
 			},
 		},
 		{
-			name:     "hash",
-			scheme:   rawdb.HashScheme,
-			archival: false,
-			expectAvailable: func(height uint64) bool {
+			name:           "hash",
+			scheme:         rawdb.HashScheme,
+			archival:       false,
+			commitInterval: defaultCommitInterval,
+			expectAvailable: func(height uint64) availability {
 				switch {
-				case saedb.ShouldCommitTrieDB(height+1, commitInterval):
+				case saedb.ShouldCommitTrieDB(height+1, defaultCommitInterval):
 					// in this test, each block settles the previous
-					return true
+					return available
 				case height == numBlocks:
 					// state committed at shutdown
-					return true
+					return available
 				case height == 0:
 					// genesis state
-					return true
+					return available
 				default:
-					return false
+					return unavailable
 				}
 			},
 		},
@@ -1173,7 +1194,7 @@ func TestRecoveryStateAvailability(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			ctx, sut := newSUT(t, options.Func[sutConfig](func(c *sutConfig) {
 				c.archival = tt.archival
-				c.commitInterval = commitInterval
+				c.commitInterval = tt.commitInterval
 				c.dbScheme = tt.scheme
 			}))
 			e, chain := sut.Executor, sut.chain
@@ -1211,11 +1232,18 @@ func TestRecoveryStateAvailability(t *testing.T) {
 				})
 
 				for _, b := range chain.AllBlocks() {
-					var wantErr testerr.Want
 					root := b.PostExecutionStateRoot()
-					if !tt.expectAvailable(b.NumberU64()) {
+
+					var wantErr testerr.Want
+					switch tt.expectAvailable(b.NumberU64()) {
+					case available:
+						wantErr = nil
+					case unavailable:
 						wantErr = missingTrieNodeError(root)
+					default:
+						continue
 					}
+
 					_, err := e.StateDB(root)
 					if diff := testerr.Diff(err, wantErr); diff != "" {
 						t.Errorf("%T.StateDB([post-execution root of block %d]) %s", e, b.NumberU64(), diff)


### PR DESCRIPTION
## Why this should be merged

Firewood RPCs rely on re-execution internally to compute state between commits. This PR is 2 more-or-less independent parts:
1. In the RPC layer, adding StateDB updates for a range of blocks if necessary.
2. In the Firewood layer, making an `ffi.Reconstruction` as necessary.

## How this works

The performance is rather critical here, and I wanted to be careful to ensure layers didn't bleed together in abstractions. All rpc code is agnostic to Firewood vs HashDB, and the Firewood layer still only assumes that the StateDB is used properly.

## How this was tested

New tests on both layers.

## Need to be documented in RELEASES.md?

Yeah probably.
