### PR TITLE
fix(blockdb): validate index initialization

### DIFF
--- a/x/blockdb/database.go
+++ b/x/blockdb/database.go
@@ -932,7 +932,13 @@ func (db *Database) openAndInitializeIndex() error {
 	if err != nil {
 		return fmt.Errorf("failed to open index file %s: %w", indexPath, err)
 	}
-	return db.loadOrInitializeHeader()
+	if err := db.loadOrInitializeHeader(); err != nil {
+		if closeErr := db.indexFile.Close(); closeErr != nil {
+			return errors.Join(err, fmt.Errorf("failed to close index file after initialization failure: %w", closeErr))
+		}
+		return err
+	}
+	return nil
 }
 
 func (db *Database) initializeDataFiles() error {
@@ -992,29 +998,17 @@ func (db *Database) loadOrInitializeHeader() error {
 	}
 	db.nextDataWriteOffset.Store(db.header.NextWriteOffset)
 	db.maxBlockHeight.Store(db.header.MaxHeight)
-	db.logConfigAndHeaderMismatches()
-
-	return nil
+	return db.validateConfigMatchesHeader()
 }
 
-func (db *Database) logConfigAndHeaderMismatches() {
-	// Some config values cannot be changed after index initialization.
-	// If they do not match the index header, log an info that
-	// the index header values will be used instead.
+func (db *Database) validateConfigMatchesHeader() error {
 	if db.config.MinimumHeight != db.header.MinHeight {
-		db.log.Info(
-			"MinimumHeight in config does not match the index header. The MinimumHeight in the index header will be used.",
-			zap.Uint64("configMinimumHeight", db.config.MinimumHeight),
-			zap.Uint64("headerMinimumHeight", db.header.MinHeight),
-		)
+		return fmt.Errorf("%w: MinimumHeight configured=%d persisted=%d", errConfigMismatch, db.config.MinimumHeight, db.header.MinHeight)
 	}
 	if db.config.MaxDataFileSize != db.header.MaxDataFileSize {
-		db.log.Info(
-			"MaxDataFileSize in config does not match the index header. The MaxDataFileSize in the index header will be used.",
-			zap.Uint64("configMaxDataFileSize", db.config.MaxDataFileSize),
-			zap.Uint64("headerMaxDataFileSize", db.header.MaxDataFileSize),
-		)
+		return fmt.Errorf("%w: MaxDataFileSize configured=%d bytes persisted=%d bytes", errConfigMismatch, db.config.MaxDataFileSize, db.header.MaxDataFileSize)
 	}
+	return nil
 }
 
 func (db *Database) closeFiles() {

--- a/x/blockdb/database_test.go
+++ b/x/blockdb/database_test.go
@@ -8,6 +8,7 @@ import (
 	"encoding/binary"
 	"errors"
 	"fmt"
+	"io"
 	"os"
 	"path/filepath"
 	"strings"
@@ -80,11 +81,11 @@ func TestNew_Params(t *testing.T) {
 	}{
 		{
 			name:   "default config",
-			config: DefaultConfig().WithDir(tempDir),
+			config: DefaultConfig().WithDir(filepath.Join(tempDir, "default")),
 		},
 		{
 			name: "custom config",
-			config: DefaultConfig().WithDir(tempDir).
+			config: DefaultConfig().WithDir(filepath.Join(tempDir, "custom")).
 				WithMinimumHeight(100).
 				WithMaxDataFileSize(1024 * 1024). // 1MB
 				WithMaxDataFiles(50).
@@ -233,47 +234,63 @@ func TestIndexEntrySizePowerOfTwo(t *testing.T) {
 		"sizeOfIndexEntry (%d) is not a power of 2", sizeOfIndexEntry)
 }
 
-func TestNew_IndexFileConfigPrecedence(t *testing.T) {
-	// set up db
-	tempDir := t.TempDir()
-	initialConfig := DefaultConfig().WithDir(tempDir).WithMinimumHeight(100).WithMaxDataFileSize(1024 * 1024)
-	db, err := New(initialConfig, logging.NoLog{})
-	require.NoError(t, err)
-	require.NotNil(t, db)
+func TestNewIndexFileConfigMismatch(t *testing.T) {
+	const (
+		persistedMinimumHeight   = 100
+		persistedMaxDataFileSize = 1024 * 1024
+	)
+	tests := []struct {
+		name            string
+		minimumHeight   uint64
+		maxDataFileSize uint64
+	}{
+		{
+			name:            "minimum_height",
+			minimumHeight:   200,
+			maxDataFileSize: persistedMaxDataFileSize,
+		},
+		{
+			name:            "max_data_file_size",
+			minimumHeight:   persistedMinimumHeight,
+			maxDataFileSize: 512 * 1024,
+		},
+	}
 
-	// Write a block at height 100 and close db
-	testBlock := []byte("test block data")
-	require.NoError(t, db.Put(100, testBlock))
-	readBlock, err := db.Get(100)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tmpDir := t.TempDir()
+			initConfig := DefaultConfig().
+				WithDir(tmpDir).
+				WithMinimumHeight(persistedMinimumHeight).
+				WithMaxDataFileSize(persistedMaxDataFileSize)
+			db, err := New(initConfig, logging.NoLog{})
+			require.NoError(t, err)
+			require.NoError(t, db.Close())
+
+			config := DefaultConfig().
+				WithDir(tmpDir).
+				WithMinimumHeight(tt.minimumHeight).
+				WithMaxDataFileSize(tt.maxDataFileSize)
+			_, err = New(config, logging.NoLog{})
+			require.ErrorIs(t, err, errConfigMismatch)
+		})
+	}
+}
+
+func TestMinimumHeightIndexOffset(t *testing.T) {
+	const minimumHeight = uint64(100)
+	dir := t.TempDir()
+	db, err := New(
+		DefaultConfig().WithDir(dir).WithMinimumHeight(minimumHeight),
+		logging.NoLog{},
+	)
 	require.NoError(t, err)
-	require.Equal(t, testBlock, readBlock)
+	require.NoError(t, db.Put(minimumHeight+1, []byte("block")))
 	require.NoError(t, db.Close())
 
-	// Reopen with different config that has minimum height of 200 and smaller max data file size
-	differentConfig := DefaultConfig().WithDir(tempDir).WithMinimumHeight(200).WithMaxDataFileSize(512 * 1024)
-	db2, err := New(differentConfig, logging.NoLog{})
+	info, err := os.Stat(filepath.Join(dir, indexFileName))
 	require.NoError(t, err)
-	require.NotNil(t, db2)
-	defer db2.Close()
-
-	// The database should still accept blocks between 100 and 200
-	testBlock2 := []byte("test block data 2")
-	require.NoError(t, db2.Put(150, testBlock2))
-	readBlock2, err := db2.Get(150)
-	require.NoError(t, err)
-	require.Equal(t, testBlock2, readBlock2)
-
-	// Verify that writing below initial minimum height fails
-	err = db2.Put(50, []byte("invalid block"))
-	require.ErrorIs(t, err, ErrInvalidBlockHeight)
-
-	// Write a large block that would exceed the new config's 512KB limit
-	// but should succeed because we use the original 1MB limit from index file
-	largeBlock := make([]byte, 768*1024) // 768KB block
-	require.NoError(t, db2.Put(200, largeBlock))
-	readLargeBlock, err := db2.Get(200)
-	require.NoError(t, err)
-	require.Equal(t, largeBlock, readLargeBlock)
+	require.Equal(t, int64(sizeOfIndexFileHeader+2*sizeOfIndexEntry), info.Size())
 }
 
 func TestFileCache_Eviction(t *testing.T) {
@@ -474,4 +491,13 @@ func TestStructSizes(t *testing.T) {
 				tt.name, tt.expectedPadding, actualMemorySize, binarySize)
 		})
 	}
+}
+
+func TestOpenAndInitializeIndexClosesFileOnFailure(t *testing.T) {
+	dir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(dir, indexFileName), []byte{0}, defaultFilePermissions))
+	db := &Database{config: DefaultConfig().WithDir(dir)}
+	require.ErrorIs(t, db.openAndInitializeIndex(), io.EOF)
+	_, err := db.indexFile.Stat()
+	require.ErrorIs(t, err, os.ErrClosed)
 }

--- a/x/blockdb/errors.go
+++ b/x/blockdb/errors.go
@@ -10,5 +10,6 @@ var (
 	ErrCorrupted          = errors.New("blockdb: unrecoverable corruption detected")
 	ErrBlockTooLarge      = errors.New("blockdb: block size too large")
 
-	errDatabaseInUse = errors.New("database directory is locked by another process")
+	errConfigMismatch = errors.New("blockdb: config does not match persisted index header")
+	errDatabaseInUse  = errors.New("database directory is locked by another process")
 )

--- a/x/blockdb/recovery_test.go
+++ b/x/blockdb/recovery_test.go
@@ -72,7 +72,7 @@ func TestRecovery_Success(t *testing.T) {
 
 				header := indexFileHeader{
 					Version:         IndexFileVersion,
-					MaxDataFileSize: 4 * 10 * 1024, // 10KB per file
+					MaxDataFileSize: 10 * 1024, // 10KB per file
 					MinHeight:       0,
 					MaxHeight:       0,
 					NextWriteOffset: firstBlockOffset,


### PR DESCRIPTION
## Why this should be merged

Reject immutable configuration mismatches and close the index file when header initialization fails. Also adds coverage for minimum-height index offsets.

Addresses items 1 (config mismatches), 2 (minimum-height index offsets), and 4 (index initialization cleanup) in #5879.

## How this works

Check `MinimumHeight` and `MaxDataFileSize` against the persisted header and return the specific mismatch. Close the opened index file before returning an initialization error.

## How this was tested

Unit tests.

## Need to be documented in RELEASES.md?

No.
