### PR TITLE
fix(blockdb): retry evicted data file handles

### DIFF
--- a/x/blockdb/config.go
+++ b/x/blockdb/config.go
@@ -8,7 +8,7 @@ import "errors"
 // DefaultMaxDataFileSize is the default maximum size of the data block file in bytes (500GB).
 const DefaultMaxDataFileSize = 500 * 1024 * 1024 * 1024
 
-// DefaultMaxDataFiles is the default maximum number of data files descriptors cached.
+// DefaultMaxDataFiles is the default maximum number of data file descriptors cached.
 const DefaultMaxDataFiles = 10
 
 // DefaultBlockCacheSize is the default size of the block cache.
@@ -28,7 +28,9 @@ type DatabaseConfig struct {
 	// MaxDataFileSize sets the maximum size of the data block file in bytes.
 	MaxDataFileSize uint64
 
-	// MaxDataFiles is the maximum number of data files descriptors cached.
+	// MaxDataFiles is the maximum number of data file descriptors cached.
+	// Most callers should use DefaultMaxDataFiles and only increase it if
+	// concurrent access to distinct data files causes descriptor churn.
 	MaxDataFiles int
 
 	// BlockCacheSize is the size of the block cache (default: 256).

--- a/x/blockdb/database.go
+++ b/x/blockdb/database.go
@@ -219,9 +219,7 @@ func New(config DatabaseConfig, log logging.Logger) (_ database.HeightIndex, err
 		config: config,
 		log:    databaseLog,
 		fileCache: lru.NewCacheWithOnEvict(config.MaxDataFiles, func(_ int, f *os.File) {
-			if f != nil {
-				f.Close()
-			}
+			f.Close()
 		}),
 		compressor: compressor,
 	}
@@ -251,12 +249,6 @@ func New(config DatabaseConfig, log logging.Logger) (_ database.HeightIndex, err
 
 	if err := db.openAndInitializeIndex(); err != nil {
 		db.log.Error("Failed to initialize database: failed to initialize index", zap.Error(err))
-		return nil, err
-	}
-
-	if err := db.initializeDataFiles(); err != nil {
-		db.log.Error("Failed to initialize database: failed to initialize data files", zap.Error(err))
-		db.closeFiles()
 		return nil, err
 	}
 
@@ -467,27 +459,12 @@ func (db *Database) Get(height BlockHeight) (BlockData, error) {
 	}
 	buf := make([]byte, int(totalReadSize))
 
-	// loop to retry fetching the data file if it got closed between get and read.
-	// If not closed, we read the block header and data.
-	for {
-		dataFile, localOffset, fileIndex, err := db.getDataFileAndOffset(indexEntry.Offset)
-		if err != nil {
-			return nil, fmt.Errorf("failed to get data file and offset: %w", err)
-		}
-		if _, err := dataFile.ReadAt(buf, int64(localOffset)); err != nil {
-			if errors.Is(err, os.ErrClosed) {
-				db.fileCache.Evict(fileIndex)
-				continue
-			}
-			db.log.Error("Failed to read block: failed to read block data from file",
-				zap.Uint64("height", height),
-				zap.Uint64("localOffset", localOffset),
-				zap.Uint32("blockSize", indexEntry.Size),
-				zap.Error(err),
-			)
-			return nil, fmt.Errorf("failed to read block header and data: %w", err)
-		}
-		break
+	dataFile, localOffset, fileIndex, err := db.getDataFileAndOffset(indexEntry.Offset)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get data file and offset: %w", err)
+	}
+	if err := db.readDataFileAt(fileIndex, dataFile, buf, int64(localOffset)); err != nil {
+		return nil, fmt.Errorf("failed to read block header and data: %w", err)
 	}
 
 	var bh blockEntryHeader
@@ -542,9 +519,9 @@ func (db *Database) getDataFileIndexForHeight(height BlockHeight) (int, error) {
 	if err != nil {
 		return 0, err
 	}
-	_, _, idx, err := db.getDataFileAndOffset(entry.Offset)
+	idx, _, err := db.dataFileIndexAndOffset(entry.Offset)
 	if err != nil {
-		return 0, fmt.Errorf("failed to get data file index for height %d: %w", height, err)
+		return 0, fmt.Errorf("%w: calculating data file index for height %d: %w", ErrCorrupted, height, err)
 	}
 	return idx, nil
 }
@@ -580,11 +557,11 @@ func (db *Database) Sync(start, end uint64) error {
 	}
 
 	for idx := firstIdx; idx <= lastIdx; idx++ {
-		f, err := db.getOrOpenDataFile(idx)
+		f, err := db.getDataFile(idx, os.O_RDWR)
 		if err != nil {
 			return fmt.Errorf("failed to open data file %d: %w", idx, err)
 		}
-		if err := f.Sync(); err != nil {
+		if err := db.retryDataFileOperation(idx, f, (*os.File).Sync); err != nil {
 			return fmt.Errorf("failed to sync data file %d: %w", idx, err)
 		}
 	}
@@ -704,6 +681,9 @@ func (db *Database) recover() error {
 	}
 
 	if len(dataFiles) == 0 {
+		if db.header.NextWriteOffset > 0 {
+			return fmt.Errorf("%w: index checkpoint is %d bytes, but no data files exist", ErrCorrupted, db.header.NextWriteOffset)
+		}
 		return nil
 	}
 
@@ -935,18 +915,6 @@ func (db *Database) openAndInitializeIndex() error {
 	return db.loadOrInitializeHeader()
 }
 
-func (db *Database) initializeDataFiles() error {
-	// Pre-load the data file for the next write offset.
-	nextOffset := db.nextDataWriteOffset.Load()
-	if nextOffset > 0 {
-		_, _, _, err := db.getDataFileAndOffset(nextOffset)
-		if err != nil {
-			return fmt.Errorf("failed to pre-load data file for offset %d: %w", nextOffset, err)
-		}
-	}
-	return nil
-}
-
 func (db *Database) loadOrInitializeHeader() error {
 	fileInfo, err := db.indexFile.Stat()
 	if err != nil {
@@ -1031,7 +999,16 @@ func (db *Database) dataFilePath(index int) string {
 	return filepath.Join(db.config.DataDir, fmt.Sprintf(dataFileNameFormat, index))
 }
 
-func (db *Database) getOrOpenDataFile(fileIndex int) (*os.File, error) {
+func (db *Database) dataFileIndexAndOffset(offset uint64) (int, uint64, error) {
+	maxFileSize := db.header.MaxDataFileSize
+	idx := offset / maxFileSize
+	if idx > math.MaxInt {
+		return 0, 0, fmt.Errorf("data file index %d exceeds maximum %d: %w", idx, math.MaxInt, safemath.ErrOverflow)
+	}
+	return int(idx), offset % maxFileSize, nil
+}
+
+func (db *Database) getDataFile(fileIndex, flags int) (*os.File, error) {
 	if handle, ok := db.fileCache.Get(fileIndex); ok {
 		return handle, nil
 	}
@@ -1046,7 +1023,7 @@ func (db *Database) getOrOpenDataFile(fileIndex int) (*os.File, error) {
 	}
 
 	filePath := db.dataFilePath(fileIndex)
-	handle, err := os.OpenFile(filePath, os.O_RDWR|os.O_CREATE, defaultFilePermissions)
+	handle, err := os.OpenFile(filePath, flags, defaultFilePermissions)
 	if err != nil {
 		db.log.Error("Failed to open data file",
 			zap.Int("fileIndex", fileIndex),
@@ -1063,6 +1040,34 @@ func (db *Database) getOrOpenDataFile(fileIndex int) (*os.File, error) {
 	)
 
 	return handle, nil
+}
+
+func (db *Database) retryDataFileOperation(idx int, f *os.File, op func(*os.File) error) error {
+	for {
+		err := op(f)
+		if !errors.Is(err, os.ErrClosed) {
+			return err
+		}
+
+		db.fileOpenMu.Lock()
+		cached, ok := db.fileCache.Get(idx)
+		if ok && cached == f {
+			db.fileCache.Evict(idx)
+		}
+		db.fileOpenMu.Unlock()
+
+		f, err = db.getDataFile(idx, os.O_RDWR)
+		if err != nil {
+			return err
+		}
+	}
+}
+
+func (db *Database) readDataFileAt(idx int, f *os.File, buf []byte, offset int64) error {
+	return db.retryDataFileOperation(idx, f, func(f *os.File) error {
+		_, err := f.ReadAt(buf, offset)
+		return err
+	})
 }
 
 func calculateChecksum(data []byte) uint64 {
@@ -1084,34 +1089,28 @@ func (db *Database) writeBlockAt(offset uint64, bh blockEntryHeader, block Block
 	copy(combinedBuf, headerBytes)
 	copy(combinedBuf[sizeOfBlockEntryHeader:], block)
 
-	// loop to retry fetching the data file if it got closed between get and write.
-	// If not closed, we write the block and return.
-	for {
-		dataFile, localOffset, fileIndex, err := db.getDataFileAndOffset(offset)
-		if err != nil {
-			return fmt.Errorf("failed to get data file for writing block %d: %w", bh.Height, err)
+	idx, localOffset, err := db.dataFileIndexAndOffset(offset)
+	if err != nil {
+		return fmt.Errorf("failed to get data file index for writing block %d: %w", bh.Height, err)
+	}
+	f, err := db.getDataFile(idx, os.O_RDWR|os.O_CREATE)
+	if err != nil {
+		return fmt.Errorf("failed to get data file for writing block %d: %w", bh.Height, err)
+	}
+	if err := db.retryDataFileOperation(idx, f, func(f *os.File) error {
+		if _, err := f.WriteAt(combinedBuf, int64(localOffset)); err != nil {
+			return fmt.Errorf("failed to write block data: %w", err)
 		}
-
-		if _, err := dataFile.WriteAt(combinedBuf, int64(localOffset)); err != nil {
-			if errors.Is(err, os.ErrClosed) {
-				// ensure the file is evicted, otherwise we'll retry forever
-				db.fileCache.Evict(fileIndex)
-				continue
-			}
-			return fmt.Errorf("failed to write block to data file at offset %d: %w", offset, err)
-		}
-
 		if db.config.SyncToDisk {
-			if err := dataFile.Sync(); err != nil {
-				if errors.Is(err, os.ErrClosed) {
-					db.fileCache.Evict(fileIndex)
-					continue
-				}
-				return fmt.Errorf("failed to sync data file after writing block %d: %w", bh.Height, err)
+			if err := f.Sync(); err != nil {
+				return fmt.Errorf("failed to sync data file: %w", err)
 			}
 		}
 		return nil
+	}); err != nil {
+		return fmt.Errorf("failed to write block to data file at offset %d: %w", offset, err)
 	}
+	return nil
 }
 
 func (db *Database) updateBlockMaxHeight(writtenBlockHeight BlockHeight) error {
@@ -1214,9 +1213,10 @@ func (db *Database) allocateBlockSpace(totalSize uint32) (writeDataOffset uint64
 }
 
 func (db *Database) getDataFileAndOffset(globalOffset uint64) (*os.File, uint64, int, error) {
-	maxFileSize := db.header.MaxDataFileSize
-	fileIndex := int(globalOffset / maxFileSize)
-	localOffset := globalOffset % maxFileSize
-	handle, err := db.getOrOpenDataFile(fileIndex)
+	fileIndex, localOffset, err := db.dataFileIndexAndOffset(globalOffset)
+	if err != nil {
+		return nil, 0, 0, err
+	}
+	handle, err := db.getDataFile(fileIndex, os.O_RDWR)
 	return handle, localOffset, fileIndex, err
 }

--- a/x/blockdb/database_test.go
+++ b/x/blockdb/database_test.go
@@ -475,3 +475,35 @@ func TestStructSizes(t *testing.T) {
 		})
 	}
 }
+
+func TestSyncRetriesClosedCachedFile(t *testing.T) {
+	db := newDatabase(t, DefaultConfig())
+	t.Cleanup(func() { require.NoError(t, db.Close()) })
+	block := []byte("block")
+	require.NoError(t, db.Put(0, block))
+
+	f, ok := db.fileCache.Get(0)
+	require.True(t, ok)
+	// Force Sync to reopen the cached data file after its handle is closed.
+	require.NoError(t, f.Close())
+
+	require.NoError(t, db.Sync(0, 0))
+	got, err := db.Get(0)
+	require.NoError(t, err)
+	require.Equal(t, block, got)
+}
+
+func TestRetryDataFileOperationPreservesReplacement(t *testing.T) {
+	db := newDatabase(t, DefaultConfig())
+	t.Cleanup(func() { require.NoError(t, db.Close()) })
+	require.NoError(t, db.Put(0, []byte("block")))
+	stale, err := db.getDataFile(0, os.O_RDWR)
+	require.NoError(t, err)
+	db.fileCache.Evict(0)
+	replacement, err := db.getDataFile(0, os.O_RDWR)
+	require.NoError(t, err)
+
+	require.NoError(t, db.retryDataFileOperation(0, stale, (*os.File).Sync))
+	_, err = replacement.Stat()
+	require.NoError(t, err)
+}

--- a/x/blockdb/readblock_test.go
+++ b/x/blockdb/readblock_test.go
@@ -7,6 +7,7 @@ import (
 	"bytes"
 	"errors"
 	"math"
+	"os"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -291,4 +292,22 @@ func TestHasBlock(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestGetMissingDataFileDoesNotCreate(t *testing.T) {
+	db := newDatabase(t, DefaultConfig())
+	require.NoError(t, db.Put(0, randomBlock(t)))
+
+	dataFilePath := db.dataFilePath(0)
+	missingDataFilePath := dataFilePath + ".missing"
+	// Force Get to reopen the missing file instead of reusing the cached handle.
+	db.fileCache.Flush()
+	require.NoError(t, os.Rename(dataFilePath, missingDataFilePath))
+
+	_, err := db.Get(0)
+	require.ErrorIs(t, err, os.ErrNotExist)
+	_, err = os.Stat(dataFilePath)
+	require.ErrorIs(t, err, os.ErrNotExist)
+	require.NoError(t, os.Rename(missingDataFilePath, dataFilePath))
+	require.NoError(t, db.Close())
 }

--- a/x/blockdb/writeblock_test.go
+++ b/x/blockdb/writeblock_test.go
@@ -273,13 +273,13 @@ func TestWriteBlock_Errors(t *testing.T) {
 			block:  make([]byte, 100),
 			setup: func(db *Database) {
 				// Change file permissions to read-only
-				file, err := db.getOrOpenDataFile(0)
+				file, err := db.getDataFile(0, os.O_RDWR|os.O_CREATE)
 				require.NoError(t, err)
 				filePath := file.Name()
 				file.Close()
 				require.NoError(t, os.Chmod(filePath, 0o444))
 			},
-			wantErrMsg: "failed to get data file for writing block",
+			wantErr: os.ErrPermission,
 		},
 		{
 			name:   "writeIndexEntryAt - index file write failure",


### PR DESCRIPTION
## Why this should be merged

A concurrent cache eviction can close a data-file handle before it is used. `Sync` needs the same retry behavior as reads and writes.

Addresses items 5 (`Sync` retries), 6 (`MaxDataFiles` guidance), and 7 (the eviction nil check) in #5879.

## How this works

Share closed-handle retries across reads, writes, and `Sync`, without evicting a newer replacement handle. Only writes create missing data files. Update the `MaxDataFiles` guidance and remove the unnecessary eviction nil check.

## How this was tested

Unit tests.

## Need to be documented in RELEASES.md?

No.
