### PR TITLE
fix(blockdb): validate indexed block heights

### DIFF
--- a/x/blockdb/database.go
+++ b/x/blockdb/database.go
@@ -494,6 +494,9 @@ func (db *Database) Get(height BlockHeight) (BlockData, error) {
 	if err := bh.UnmarshalBinary(buf[:int(sizeOfBlockEntryHeader)]); err != nil {
 		return nil, fmt.Errorf("failed to deserialize block header: %w", err)
 	}
+	if bh.Height != height {
+		return nil, fmt.Errorf("%w: requested block height %d does not match stored height %d", ErrCorrupted, height, bh.Height)
+	}
 	compressedData := buf[int(sizeOfBlockEntryHeader):]
 	decompressed, err := db.compressor.Decompress(compressedData)
 	if err != nil {

--- a/x/blockdb/readblock_test.go
+++ b/x/blockdb/readblock_test.go
@@ -292,3 +292,18 @@ func TestHasBlock(t *testing.T) {
 		})
 	}
 }
+
+func TestGetRejectsIndexedHeightMismatch(t *testing.T) {
+	db := newDatabase(t, DefaultConfig())
+	t.Cleanup(func() { require.NoError(t, db.Close()) })
+	require.NoError(t, db.Put(0, []byte("first block")))
+	require.NoError(t, db.Put(1, []byte("second block")))
+	entry, err := db.readIndexEntry(1)
+	require.NoError(t, err)
+	offset, err := db.indexEntryOffset(0)
+	require.NoError(t, err)
+	require.NoError(t, db.writeIndexEntryAt(offset, entry.Offset, entry.Size))
+
+	_, err = db.Get(0)
+	require.ErrorIs(t, err, ErrCorrupted)
+}


### PR DESCRIPTION
## Why this should be merged

A corrupted index can point to another valid record, causing `Get` to return the wrong block even when its checksum passes.

Addresses item 3 (indexed record height validation) in #5879.

## How this works

Return `ErrCorrupted` when the stored record height differs from the requested height.

## How this was tested

Unit tests.

## Need to be documented in RELEASES.md?

No.
