### PR TITLE
fix(blockdb): preserve indexed data during recovery

### DIFF
--- a/x/blockdb/database.go
+++ b/x/blockdb/database.go
@@ -472,40 +472,40 @@ func (db *Database) Get(height BlockHeight) (BlockData, error) {
 		return nil, err
 	}
 
-	totalReadSize, err := safemath.Add(uint64(sizeOfBlockEntryHeader), uint64(indexEntry.Size))
+	dataEnd, err := db.dataFileEndForOffset(indexEntry.Offset)
 	if err != nil {
-		return nil, fmt.Errorf("failed to compute total read size: %w", err)
+		if errors.Is(err, ErrCorrupted) {
+			return nil, db.blockUnavailableError(height, indexEntry, err)
+		}
+		return nil, err
 	}
-	buf := make([]byte, int(totalReadSize))
-
-	dataFile, localOffset, fileIndex, err := db.getDataFileAndOffset(indexEntry.Offset)
+	bh, block, err := db.readBlockAtOffset(indexEntry.Offset, dataEnd, &indexEntry.Size)
 	if err != nil {
-		return nil, fmt.Errorf("failed to get data file and offset: %w", err)
-	}
-	if err := db.readDataFileAt(fileIndex, dataFile, buf, int64(localOffset)); err != nil {
-		return nil, fmt.Errorf("failed to read block header and data: %w", err)
-	}
-
-	var bh blockEntryHeader
-	if err := bh.UnmarshalBinary(buf[:int(sizeOfBlockEntryHeader)]); err != nil {
-		return nil, fmt.Errorf("failed to deserialize block header: %w", err)
+		if errors.Is(err, ErrCorrupted) {
+			return nil, db.blockUnavailableError(height, indexEntry, err)
+		}
+		return nil, err
 	}
 	if bh.Height != height {
-		return nil, fmt.Errorf("%w: requested block height %d does not match stored height %d", ErrCorrupted, height, bh.Height)
-	}
-	compressedData := buf[int(sizeOfBlockEntryHeader):]
-	decompressed, err := db.compressor.Decompress(compressedData)
-	if err != nil {
-		return nil, fmt.Errorf("failed to decompress block data: %w", err)
-	}
-
-	// Verify checksum on uncompressed data
-	calculatedChecksum := calculateChecksum(decompressed)
-	if calculatedChecksum != bh.Checksum {
-		return nil, fmt.Errorf("checksum mismatch: calculated %d, stored %d", calculatedChecksum, bh.Checksum)
+		return nil, db.blockUnavailableError(height, indexEntry, fmt.Errorf(
+			"%w: requested block height %d does not match stored height %d",
+			ErrCorrupted,
+			height,
+			bh.Height,
+		))
 	}
 
-	return decompressed, nil
+	return block, nil
+}
+
+func (db *Database) blockUnavailableError(height BlockHeight, entry indexEntry, err error) error {
+	db.log.Error("Indexed block data is unavailable",
+		zap.Uint64("height", height),
+		zap.Uint64("dataOffset", entry.Offset),
+		zap.Uint32("indexedSize", entry.Size),
+		zap.Error(err),
+	)
+	return fmt.Errorf("block at height %d is unavailable: %w", height, err)
 }
 
 // Has checks if a block exists at the given height.
@@ -735,69 +735,76 @@ func (db *Database) dataFileEnd(idx int, path string) (uint64, error) {
 	return fileEnd, nil
 }
 
+func (db *Database) dataFileEndForOffset(offset uint64) (uint64, error) {
+	idx, _, err := db.dataFileIndexAndOffset(offset)
+	if err != nil {
+		return 0, fmt.Errorf("%w: calculating data file index for offset %d: %w", ErrCorrupted, offset, err)
+	}
+	fileEnd, err := db.dataFileEnd(idx, db.dataFilePath(idx))
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return 0, fmt.Errorf("%w: indexed data file %d does not exist", ErrCorrupted, idx)
+		}
+		return 0, err
+	}
+	if offset >= fileEnd {
+		return 0, fmt.Errorf("%w: index offset %d is outside data file %d", ErrCorrupted, offset, idx)
+	}
+	return fileEnd, nil
+}
+
 // recover detects and recovers unindexed blocks by scanning data files and updating the index.
 // It compares the actual data file sizes on disk with the indexed data size to detect
 // blocks that were written but not properly indexed.
 // For each unindexed block found, it validates the block, then
 // writes the corresponding index entry and updates block height tracking.
 func (db *Database) recover() error {
-	dataFiles, maxIndex, err := db.listDataFiles()
+	checkpoint := db.header.NextWriteOffset
+	files, maxIdx, err := db.listDataFiles()
 	if err != nil {
 		return fmt.Errorf("failed to list data files for recovery: %w", err)
 	}
 
-	if len(dataFiles) == 0 {
-		if db.header.NextWriteOffset > 0 {
-			return fmt.Errorf("%w: index checkpoint is %d bytes, but no data files exist", ErrCorrupted, db.header.NextWriteOffset)
+	if len(files) == 0 {
+		if checkpoint > 0 {
+			return fmt.Errorf(
+				"%w: index checkpoint is %d bytes, but no data files exist",
+				ErrCorrupted,
+				checkpoint,
+			)
 		}
 		return nil
 	}
 
-	if db.header.MaxDataFileSize == math.MaxUint64 && len(dataFiles) > 1 {
-		return fmt.Errorf("%w: only one data file expected when MaxDataFileSize is max uint64, got %d files with max index %d", ErrCorrupted, len(dataFiles), maxIndex)
+	if db.header.MaxDataFileSize == math.MaxUint64 && len(files) > 1 {
+		return fmt.Errorf("%w: only one data file expected when MaxDataFileSize is max uint64, got %d files with max index %d", ErrCorrupted, len(files), maxIdx)
 	}
 
-	// ensure no data files are missing
-	// If any data files are missing, we would need to recalculate the max height.
-	// This can be supported in the future but for now to keep things simple,
-	// we will just error if the data files are not as expected.
-	for i := 0; i <= maxIndex; i++ {
-		if _, exists := dataFiles[i]; !exists {
+	// File presence and extent are cheap structural checks. Recovery does not
+	// rescan record contents before the persisted checkpoint.
+	for i := 0; i <= maxIdx; i++ {
+		if _, ok := files[i]; !ok {
 			return fmt.Errorf("%w: data file at index %d is missing", ErrCorrupted, i)
 		}
 	}
 
-	// Calculate the expected next write offset based on the data on disk.
-	var calculatedNextDataWriteOffset uint64
-	fileSizeContribution, err := safemath.Mul(uint64(maxIndex), db.header.MaxDataFileSize)
+	dataEnd, err := db.calculatePhysicalDataEnd(files, maxIdx)
 	if err != nil {
-		return fmt.Errorf("calculating file size contribution would overflow: %w", err)
-	}
-	calculatedNextDataWriteOffset = fileSizeContribution
-
-	lastFileInfo, err := os.Stat(dataFiles[maxIndex])
-	if err != nil {
-		return fmt.Errorf("failed to get stats for last data file %s: %w", dataFiles[maxIndex], err)
-	}
-	calculatedNextDataWriteOffset, err = safemath.Add(calculatedNextDataWriteOffset, uint64(lastFileInfo.Size()))
-	if err != nil {
-		return fmt.Errorf("adding last file size would overflow: %w", err)
+		return err
 	}
 
-	nextDataReservationOffset := db.nextDataReservationOffset.Load()
 	switch {
-	case calculatedNextDataWriteOffset == nextDataReservationOffset:
+	case dataEnd == checkpoint:
 		db.log.Debug("Recovery: data files match index header, no recovery needed.")
 		return nil
 
-	case calculatedNextDataWriteOffset < nextDataReservationOffset:
-		// this happens when the index claims to have more data than is actually on disk
-		return fmt.Errorf("%w: index header claims to have more data than is actually on disk "+
-			"(calculated: %d bytes, index header: %d bytes)",
-			ErrCorrupted, calculatedNextDataWriteOffset, nextDataReservationOffset)
+	case dataEnd < checkpoint:
+		return fmt.Errorf("%w: index checkpoint is ahead of physical data "+
+			"(physical data end: %d bytes, checkpoint: %d bytes)",
+			ErrCorrupted, dataEnd, checkpoint)
 	default:
 		// The data on disk is ahead of the index. We need to recover unindexed blocks.
-		if err := db.recoverUnindexedBlocks(nextDataReservationOffset, calculatedNextDataWriteOffset); err != nil {
+		if err := db.recoverUnindexedBlocks(checkpoint, dataEnd); err != nil {
 			return err
 		}
 	}
@@ -812,27 +819,49 @@ func (db *Database) recoverUnindexedBlocks(startOffset, endOffset uint64) error 
 	)
 
 	var (
-		// Start scan from where the index left off.
+		// Start at the persisted checkpoint, where the index was last synchronized.
 		currentScanOffset   = startOffset
 		numRecoveredHeights int
-		maxRecoveredHeight  BlockHeight
+		currentFileIndex    = -1
+		currentFileEnd      uint64
+		badOffset           uint64
+		badErr              error
 	)
 	for currentScanOffset < endOffset {
-		bh, err := db.recoverBlockAtOffset(currentScanOffset, endOffset)
+		idx, _, err := db.dataFileIndexAndOffset(currentScanOffset)
 		if err != nil {
-			if errors.Is(err, io.EOF) {
-				// Reached end of this file, try to read the next file
-				currentFileIndex := int(currentScanOffset / db.header.MaxDataFileSize)
-				nextFileIndex, err := safemath.Add(uint64(currentFileIndex), 1)
-				if err != nil {
-					return fmt.Errorf("recovery: overflow in file index calculation: %w", err)
-				}
-				if currentScanOffset, err = safemath.Mul(nextFileIndex, db.header.MaxDataFileSize); err != nil {
-					return fmt.Errorf("recovery: overflow in scan offset calculation: %w", err)
-				}
-				continue
+			return fmt.Errorf("recovery: %w: calculating data file index for offset %d: %w", ErrCorrupted, currentScanOffset, err)
+		}
+		if idx != currentFileIndex {
+			currentFileIndex = idx
+			fileEnd, err := db.dataFileEnd(currentFileIndex, db.dataFilePath(currentFileIndex))
+			if err != nil {
+				return fmt.Errorf("recovery: %w", err)
 			}
-			return err
+			currentFileEnd = fileEnd
+		}
+		if currentScanOffset >= currentFileEnd {
+			// A block that crosses a file boundary leaves this file's remaining range unused.
+			nextIdx, err := safemath.Add(uint64(currentFileIndex), 1)
+			if err != nil {
+				return fmt.Errorf("recovery: overflow in file index calculation: %w", err)
+			}
+			if currentScanOffset, err = safemath.Mul(nextIdx, db.header.MaxDataFileSize); err != nil {
+				return fmt.Errorf("recovery: overflow in scan offset calculation: %w", err)
+			}
+			continue
+		}
+
+		bh, err := db.recoverBlockAtOffset(currentScanOffset, currentFileEnd)
+		if err != nil {
+			if !errors.Is(err, ErrCorrupted) {
+				return err
+			}
+			badOffset = currentScanOffset
+			badErr = err
+			// The checkpoint header can lag a later index entry, so preserve this suffix.
+			currentScanOffset = endOffset
+			break
 		}
 		db.log.Debug("Recovery: Successfully validated and indexed block",
 			zap.Uint64("height", bh.Height),
@@ -840,107 +869,175 @@ func (db *Database) recoverUnindexedBlocks(startOffset, endOffset uint64) error 
 			zap.Uint64("dataOffset", currentScanOffset),
 		)
 		numRecoveredHeights++
-		maxRecoveredHeight = max(maxRecoveredHeight, bh.Height)
-		blockTotalSize, err := safemath.Add(uint64(sizeOfBlockEntryHeader), uint64(bh.Size))
+		db.updateBlockMaxHeight(bh.Height)
+		blockSize, err := safemath.Add(uint64(sizeOfBlockEntryHeader), uint64(bh.Size))
 		if err != nil {
 			return fmt.Errorf("recovery: overflow in block size calculation: %w", err)
 		}
-		currentScanOffset, err = safemath.Add(currentScanOffset, blockTotalSize)
+		currentScanOffset, err = safemath.Add(currentScanOffset, blockSize)
 		if err != nil {
 			return fmt.Errorf("recovery: overflow in scan offset calculation: %w", err)
 		}
 	}
+	// Append after recovered data and any malformed suffix left as an orphan.
 	db.nextDataReservationOffset.Store(currentScanOffset)
-
-	// Update the max block height if max recovered height is greater than
-	// the current max height.
-	if numRecoveredHeights > 0 {
-		currentMaxHeight := db.maxBlockHeight.Load()
-		if maxRecoveredHeight > currentMaxHeight || currentMaxHeight == unsetHeight {
-			db.maxBlockHeight.Store(maxRecoveredHeight)
+	if badErr != nil {
+		// Valid entries past malformed data need a max-height update or Get
+		// short-circuits before reading them.
+		info, err := db.indexFile.Stat()
+		if err != nil {
+			return fmt.Errorf("recovery: failed to get index file stats: %w", err)
+		}
+		indexSize := uint64(info.Size())
+		if indexSize > sizeOfIndexFileHeader {
+			entryCount := (indexSize - sizeOfIndexFileHeader) / sizeOfIndexEntry
+			for entryCount > 0 {
+				entryCount--
+				height, err := safemath.Add(db.header.MinHeight, entryCount)
+				if err != nil {
+					return fmt.Errorf("recovery: %w: calculating max indexed height: %w", ErrCorrupted, err)
+				}
+				entry, err := db.readIndexEntry(height)
+				if errors.Is(err, database.ErrNotFound) {
+					continue
+				}
+				if err != nil {
+					return fmt.Errorf("recovery: failed to read index entry at height %d: %w", height, err)
+				}
+				dataEnd, err := db.dataFileEndForOffset(entry.Offset)
+				if errors.Is(err, ErrCorrupted) {
+					continue
+				}
+				if err != nil {
+					return fmt.Errorf("recovery: failed to get data end for indexed block %d: %w", height, err)
+				}
+				bh, _, err := db.readBlockAtOffset(entry.Offset, dataEnd, &entry.Size)
+				if errors.Is(err, ErrCorrupted) {
+					continue
+				}
+				if err != nil {
+					return fmt.Errorf("recovery: failed to validate indexed block %d: %w", height, err)
+				}
+				if bh.Height == height {
+					db.updateBlockMaxHeight(height)
+					break
+				}
+			}
 		}
 	}
 
 	if err := db.persistIndexHeader(); err != nil {
 		return fmt.Errorf("recovery: failed to save index header after recovery scan: %w", err)
 	}
+	if badErr != nil {
+		db.log.Warn("Recovery stopped at malformed data; remaining suffix left orphaned",
+			zap.Uint64("dataOffset", badOffset),
+			zap.Uint64("dataEnd", endOffset),
+			zap.Error(badErr),
+		)
+	}
 
 	maxHeight := db.maxBlockHeight.Load()
 	db.log.Info("Recovery: Scan finished",
 		zap.Int("recoveredBlocks", numRecoveredHeights),
-		zap.Uint64("finalNextWriteOffset", db.nextDataReservationOffset.Load()),
+		zap.Uint64("finalNextDataReservationOffset", db.nextDataReservationOffset.Load()),
 		zap.Uint64("maxBlockHeight", maxHeight),
 	)
 	return nil
 }
 
-func (db *Database) recoverBlockAtOffset(offset, totalDataSize uint64) (blockEntryHeader, error) {
+func (db *Database) recoverBlockAtOffset(offset, fileEndOffset uint64) (blockEntryHeader, error) {
+	bh, _, err := db.readBlockAtOffset(offset, fileEndOffset, nil)
+	if err != nil {
+		return bh, err
+	}
+	indexOffset, err := db.indexEntryOffset(bh.Height)
+	if err != nil {
+		return bh, fmt.Errorf("%w: cannot get index offset for recovered block %d: %w", ErrCorrupted, bh.Height, err)
+	}
+	if err := db.writeIndexEntryAt(indexOffset, offset, bh.Size); err != nil {
+		return bh, fmt.Errorf("failed to write index entry for recovered block %d: %w", bh.Height, err)
+	}
+	return bh, nil
+}
+
+func (db *Database) readBlockAtOffset(offset, fileEndOffset uint64, indexedSize *uint32) (blockEntryHeader, BlockData, error) {
 	var bh blockEntryHeader
-	if totalDataSize-offset < uint64(sizeOfBlockEntryHeader) {
-		return bh, fmt.Errorf("%w: not enough data for block header at offset %d", ErrCorrupted, offset)
+	if fileEndOffset-offset < uint64(sizeOfBlockEntryHeader) {
+		return bh, nil, fmt.Errorf("%w: not enough data for block header at offset %d", ErrCorrupted, offset)
 	}
 
-	dataFile, localOffset, _, err := db.getDataFileAndOffset(offset)
+	idx, localOffset, err := db.dataFileIndexAndOffset(offset)
 	if err != nil {
-		return bh, fmt.Errorf("recovery: failed to get data file for offset %d: %w", offset, err)
+		return bh, nil, fmt.Errorf("%w: calculating data file index for offset %d: %w", ErrCorrupted, offset, err)
+	}
+	f, err := db.getDataFile(idx, os.O_RDWR)
+	if err != nil {
+		return bh, nil, blockReadError("header", offset, err)
 	}
 	bhBuf := make([]byte, sizeOfBlockEntryHeader)
-	if _, err := dataFile.ReadAt(bhBuf, int64(localOffset)); err != nil {
-		return bh, fmt.Errorf("%w: error reading block header at offset %d: %w", ErrCorrupted, offset, err)
+	if err := db.readDataFileAt(idx, f, bhBuf, int64(localOffset)); err != nil {
+		return bh, nil, blockReadError("header", offset, err)
 	}
 	if err := bh.UnmarshalBinary(bhBuf); err != nil {
-		return bh, fmt.Errorf("%w: error deserializing block header at offset %d: %w", ErrCorrupted, offset, err)
+		return bh, nil, fmt.Errorf("%w: error deserializing block header at offset %d: %w", ErrCorrupted, offset, err)
 	}
 	if bh.Size == 0 {
-		return bh, fmt.Errorf("%w: invalid block size in header at offset %d: %d", ErrCorrupted, offset, bh.Size)
+		return bh, nil, fmt.Errorf("%w: invalid block size in header at offset %d: %d", ErrCorrupted, offset, bh.Size)
+	}
+	// Validate the indexed size before allocating based on the stored header.
+	if indexedSize != nil && bh.Size != *indexedSize {
+		return bh, nil, fmt.Errorf("%w: indexed block size %d does not match stored size %d", ErrCorrupted, *indexedSize, bh.Size)
 	}
 	if bh.Version > BlockEntryVersion {
-		return bh, fmt.Errorf("%w: invalid block entry version at offset %d, version %d is greater than the current version %d", ErrCorrupted, offset, bh.Version, BlockEntryVersion)
+		return bh, nil, fmt.Errorf("%w: invalid block entry version at offset %d, version %d is greater than the current version %d", ErrCorrupted, offset, bh.Version, BlockEntryVersion)
 	}
 	if bh.Height < db.header.MinHeight || bh.Height == unsetHeight {
-		return bh, fmt.Errorf(
+		return bh, nil, fmt.Errorf(
 			"%w: invalid block height in header at offset %d: found %d, expected >= %d",
 			ErrCorrupted, offset, bh.Height, db.header.MinHeight,
 		)
 	}
-	expectedBlockEndOffset, err := safemath.Add(offset, uint64(sizeOfBlockEntryHeader))
+	blockEnd, err := safemath.Add(offset, uint64(sizeOfBlockEntryHeader))
 	if err != nil {
-		return bh, fmt.Errorf("calculating block end offset would overflow at offset %d: %w", offset, err)
+		return bh, nil, fmt.Errorf("%w: calculating block end offset would overflow at offset %d: %w", ErrCorrupted, offset, err)
 	}
-	expectedBlockEndOffset, err = safemath.Add(expectedBlockEndOffset, uint64(bh.Size))
+	blockEnd, err = safemath.Add(blockEnd, uint64(bh.Size))
 	if err != nil {
-		return bh, fmt.Errorf("calculating block end offset would overflow at offset %d: %w", offset, err)
+		return bh, nil, fmt.Errorf("%w: calculating block end offset would overflow at offset %d: %w", ErrCorrupted, offset, err)
 	}
-	if expectedBlockEndOffset > totalDataSize {
-		return bh, fmt.Errorf("%w: block data out of bounds at offset %d", ErrCorrupted, offset)
+	if blockEnd > fileEndOffset {
+		return bh, nil, fmt.Errorf("%w: block data out of bounds at offset %d", ErrCorrupted, offset)
 	}
-	blockData := make([]byte, bh.Size)
-	blockDataOffset, err := safemath.Add(localOffset, uint64(sizeOfBlockEntryHeader))
+	compressed := make([]byte, bh.Size)
+	dataOffset, err := safemath.Add(localOffset, uint64(sizeOfBlockEntryHeader))
 	if err != nil {
-		return bh, fmt.Errorf("calculating block data offset would overflow at offset %d: %w", offset, err)
+		return bh, nil, fmt.Errorf("%w: calculating block data offset would overflow at offset %d: %w", ErrCorrupted, offset, err)
 	}
-	if _, err := dataFile.ReadAt(blockData, int64(blockDataOffset)); err != nil {
-		return bh, fmt.Errorf("%w: failed to read block data at offset %d: %w", ErrCorrupted, offset, err)
+	if err := db.readDataFileAt(idx, f, compressed, int64(dataOffset)); err != nil {
+		return bh, nil, blockReadError("data", offset, err)
 	}
-	// Decompress block data and verify checksum
-	decompressed, err := db.compressor.Decompress(blockData)
+	block, err := db.compressor.Decompress(compressed)
 	if err != nil {
-		return bh, fmt.Errorf("%w: failed to decompress block at offset %d: %w", ErrCorrupted, offset, err)
+		return bh, nil, fmt.Errorf("%w: failed to decompress block at offset %d: %w", ErrCorrupted, offset, err)
 	}
-	calculatedChecksum := calculateChecksum(decompressed)
-	if calculatedChecksum != bh.Checksum {
-		return bh, fmt.Errorf("%w: checksum mismatch for block at offset %d", ErrCorrupted, offset)
+	checksum := calculateChecksum(block)
+	if checksum != bh.Checksum {
+		return bh, nil, fmt.Errorf("%w: checksum mismatch for block at offset %d", ErrCorrupted, offset)
 	}
 
-	// Write index entry for this block
-	indexFileOffset, idxErr := db.indexEntryOffset(bh.Height)
-	if idxErr != nil {
-		return bh, fmt.Errorf("cannot get index offset for recovered block %d: %w", bh.Height, idxErr)
+	return bh, block, nil
+}
+
+func blockReadError(part string, offset uint64, err error) error {
+	switch {
+	case errors.Is(err, io.EOF), errors.Is(err, io.ErrUnexpectedEOF):
+		return fmt.Errorf("%w: incomplete block %s at offset %d: %w", ErrCorrupted, part, offset, err)
+	case errors.Is(err, os.ErrNotExist):
+		return fmt.Errorf("%w: data file for offset %d does not exist: %w", ErrCorrupted, offset, err)
+	default:
+		return fmt.Errorf("failed to read block %s at offset %d: %w", part, offset, err)
 	}
-	if err := db.writeIndexEntryAt(indexFileOffset, offset, bh.Size); err != nil {
-		return bh, fmt.Errorf("failed to update index for recovered block %d: %w", bh.Height, err)
-	}
-	return bh, nil
 }
 
 func (db *Database) listDataFiles() (map[int]string, int, error) {
@@ -1271,13 +1368,4 @@ func (db *Database) allocateBlockSpace(totalSize uint32) (dataReservation, error
 			}, nil
 		}
 	}
-}
-
-func (db *Database) getDataFileAndOffset(globalOffset uint64) (*os.File, uint64, int, error) {
-	fileIndex, localOffset, err := db.dataFileIndexAndOffset(globalOffset)
-	if err != nil {
-		return nil, 0, 0, err
-	}
-	handle, err := db.getDataFile(fileIndex, os.O_RDWR)
-	return handle, localOffset, fileIndex, err
 }

--- a/x/blockdb/database.go
+++ b/x/blockdb/database.go
@@ -841,7 +841,7 @@ func (db *Database) recoverUnindexedBlocks(startOffset, endOffset uint64) error 
 			currentFileEnd = fileEnd
 		}
 		if currentScanOffset >= currentFileEnd {
-			// A block that crosses a file boundary leaves this file's remaining range unused.
+			// When a block does not fit, writing continues in the next file.
 			nextIdx, err := safemath.Add(uint64(currentFileIndex), 1)
 			if err != nil {
 				return fmt.Errorf("recovery: overflow in file index calculation: %w", err)

--- a/x/blockdb/database_test.go
+++ b/x/blockdb/database_test.go
@@ -9,6 +9,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"math"
 	"os"
 	"path/filepath"
 	"strings"
@@ -24,6 +25,8 @@ import (
 	"github.com/ava-labs/avalanchego/database/heightindexdb/dbtest"
 	"github.com/ava-labs/avalanchego/utils/compression"
 	"github.com/ava-labs/avalanchego/utils/logging"
+
+	safemath "github.com/ava-labs/avalanchego/utils/math"
 )
 
 func TestInterface(t *testing.T) {
@@ -559,4 +562,16 @@ func TestCloseRejectsCheckpointPastPhysicalData(t *testing.T) {
 
 	require.NoError(t, os.Truncate(db.dataFilePath(0), info.Size()))
 	require.ErrorIs(t, db.Close(), ErrCorrupted)
+}
+
+func TestGetRejectsUnrepresentableDataFileIndex(t *testing.T) {
+	db := newDatabase(t, DefaultConfig().WithMaxDataFileSize(1))
+	indexOffset, err := db.indexEntryOffset(0)
+	require.NoError(t, err)
+	require.NoError(t, db.writeIndexEntryAt(indexOffset, uint64(math.MaxInt)+1, 1))
+	db.maxBlockHeight.Store(0)
+
+	_, err = db.Get(0)
+	require.ErrorIs(t, err, ErrCorrupted)
+	require.ErrorIs(t, err, safemath.ErrOverflow)
 }

--- a/x/blockdb/errors.go
+++ b/x/blockdb/errors.go
@@ -7,7 +7,7 @@ import "errors"
 
 var (
 	ErrInvalidBlockHeight = errors.New("blockdb: invalid block height")
-	ErrCorrupted          = errors.New("blockdb: unrecoverable corruption detected")
+	ErrCorrupted          = errors.New("blockdb: corrupted data")
 	ErrBlockTooLarge      = errors.New("blockdb: block size too large")
 
 	errConfigMismatch = errors.New("blockdb: config does not match persisted index header")

--- a/x/blockdb/readblock_test.go
+++ b/x/blockdb/readblock_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/ava-labs/avalanchego/database"
+	"github.com/ava-labs/avalanchego/utils/compression"
 )
 
 func TestReadOperations(t *testing.T) {
@@ -305,7 +306,7 @@ func TestGetMissingDataFileDoesNotCreate(t *testing.T) {
 	require.NoError(t, os.Rename(dataFilePath, missingDataFilePath))
 
 	_, err := db.Get(0)
-	require.ErrorIs(t, err, os.ErrNotExist)
+	require.ErrorIs(t, err, ErrCorrupted)
 	_, err = os.Stat(dataFilePath)
 	require.ErrorIs(t, err, os.ErrNotExist)
 	require.NoError(t, os.Rename(missingDataFilePath, dataFilePath))
@@ -325,4 +326,71 @@ func TestGetRejectsIndexedHeightMismatch(t *testing.T) {
 
 	_, err = db.Get(0)
 	require.ErrorIs(t, err, ErrCorrupted)
+}
+
+func TestGetCorruptedRecord(t *testing.T) {
+	block := []byte("block")
+	blockSize := uint32(len(block))
+	checksum := calculateChecksum(block)
+	tests := []struct {
+		name        string
+		header      blockEntryHeader
+		indexedSize uint32
+	}{
+		{
+			name: "indexed_size_mismatch",
+			header: blockEntryHeader{
+				Size:     blockSize,
+				Checksum: checksum,
+				Version:  BlockEntryVersion,
+			},
+			indexedSize: math.MaxUint32,
+		},
+		{
+			name: "zero_stored_size",
+			header: blockEntryHeader{
+				Checksum: checksum,
+				Version:  BlockEntryVersion,
+			},
+			indexedSize: blockSize,
+		},
+		{
+			name: "unsupported_version",
+			header: blockEntryHeader{
+				Size:     blockSize,
+				Checksum: checksum,
+				Version:  BlockEntryVersion + 1,
+			},
+			indexedSize: blockSize,
+		},
+		{
+			name: "checksum_mismatch",
+			header: blockEntryHeader{
+				Size:     blockSize,
+				Checksum: checksum + 1,
+				Version:  BlockEntryVersion,
+			},
+			indexedSize: blockSize,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			db := newDatabase(t, DefaultConfig())
+			db.compressor = compression.NewNoCompressor()
+			require.NoError(t, db.Put(0, block))
+
+			entry, err := db.readIndexEntry(0)
+			require.NoError(t, err)
+			require.NoError(t, writeBlockHeader(db, int64(entry.Offset), tt.header))
+			indexOffset, err := db.indexEntryOffset(0)
+			require.NoError(t, err)
+			require.NoError(t, db.writeIndexEntryAt(indexOffset, entry.Offset, tt.indexedSize))
+
+			_, err = db.Get(0)
+			require.ErrorIs(t, err, ErrCorrupted)
+			require.NotErrorIs(t, err, database.ErrNotFound)
+			require.NoError(t, db.Close())
+		})
+	}
 }

--- a/x/blockdb/recovery_test.go
+++ b/x/blockdb/recovery_test.go
@@ -6,12 +6,14 @@ package blockdb
 import (
 	"fmt"
 	"math"
+	"math/rand/v2"
 	"os"
 	"testing"
 
 	"github.com/DataDog/zstd"
 	"github.com/stretchr/testify/require"
 
+	"github.com/ava-labs/avalanchego/database"
 	"github.com/ava-labs/avalanchego/utils"
 	"github.com/ava-labs/avalanchego/utils/compression"
 )
@@ -242,8 +244,15 @@ func TestRecovery_CorruptionDetection(t *testing.T) {
 		blockSize          int // Optional: if set, creates fixed-size blocks instead of random
 		setupCorruption    func(store *Database, blocks [][]byte) error
 		wantErr            error
-		wantErrText        string
 	}{
+		{
+			name:         "checkpoint_references_missing_data",
+			blockHeights: []uint64{0},
+			setupCorruption: func(store *Database, _ [][]byte) error {
+				return os.Remove(store.dataFilePath(0))
+			},
+			wantErr: ErrCorrupted,
+		},
 		{
 			name:         "index header claims larger offset than actual data",
 			blockHeights: []uint64{0, 1, 2, 3, 4},
@@ -278,8 +287,7 @@ func TestRecovery_CorruptionDetection(t *testing.T) {
 				_, err = indexFile.WriteAt(corruptedHeaderBytes, 0)
 				return err
 			},
-			wantErr:     ErrCorrupted,
-			wantErrText: "index header claims to have more data than is actually on disk",
+			wantErr: ErrCorrupted,
 		},
 		{
 			name:         "corrupted block header in data file",
@@ -307,8 +315,6 @@ func TestRecovery_CorruptionDetection(t *testing.T) {
 				_, err = dataFile.WriteAt(corruptedHeader, secondBlockOffset)
 				return err
 			},
-			wantErr:     ErrCorrupted,
-			wantErrText: "invalid block entry version at offset",
 		},
 		{
 			name:         "block with invalid block size in header that reads more than total data file size",
@@ -334,8 +340,6 @@ func TestRecovery_CorruptionDetection(t *testing.T) {
 				}
 				return writeBlockHeader(store, secondBlockOffset, bh)
 			},
-			wantErr:     ErrCorrupted,
-			wantErrText: "block data out of bounds at offset ",
 		},
 		{
 			name:         "block with checksum mismatch",
@@ -361,8 +365,6 @@ func TestRecovery_CorruptionDetection(t *testing.T) {
 				}
 				return writeBlockHeader(store, secondBlockOffset, bh)
 			},
-			wantErr:     ErrCorrupted,
-			wantErrText: "checksum mismatch for block",
 		},
 		{
 			name:         "partial block at end of file",
@@ -383,8 +385,7 @@ func TestRecovery_CorruptionDetection(t *testing.T) {
 				truncateSize := int64(sizeOfBlockEntryHeader) + int64(compressedSize)/2
 				return dataFile.Truncate(truncateSize)
 			},
-			wantErr:     ErrCorrupted,
-			wantErrText: "index header claims to have more data than is actually on disk",
+			wantErr: ErrCorrupted,
 		},
 		{
 			name:         "block with invalid height",
@@ -411,8 +412,6 @@ func TestRecovery_CorruptionDetection(t *testing.T) {
 				}
 				return writeBlockHeader(store, secondBlockOffset, bh)
 			},
-			wantErr:     ErrCorrupted,
-			wantErrText: "invalid block height in header",
 		},
 		{
 			name:               "missing data file at index 1",
@@ -425,8 +424,7 @@ func TestRecovery_CorruptionDetection(t *testing.T) {
 				dataFilePath := store.dataFilePath(1)
 				return os.Remove(dataFilePath)
 			},
-			wantErr:     ErrCorrupted,
-			wantErrText: "data file at index 1 is missing",
+			wantErr: ErrCorrupted,
 		},
 		{
 			name:            "unexpected multiple data files when MaxDataFileSize is max uint64",
@@ -447,8 +445,7 @@ func TestRecovery_CorruptionDetection(t *testing.T) {
 				_, err = secondDataFile.Write(dummyData)
 				return err
 			},
-			wantErr:     ErrCorrupted,
-			wantErrText: "only one data file expected when MaxDataFileSize is max uint64, got 2 files with max index 1",
+			wantErr: ErrCorrupted,
 		},
 		{
 			name:         "block with invalid block entry version",
@@ -475,8 +472,6 @@ func TestRecovery_CorruptionDetection(t *testing.T) {
 				}
 				return writeBlockHeader(store, secondBlockOffset, bh)
 			},
-			wantErr:     ErrCorrupted,
-			wantErrText: "invalid block entry version at offset",
 		},
 		{
 			name:         "second block with invalid version among 4 blocks",
@@ -503,8 +498,6 @@ func TestRecovery_CorruptionDetection(t *testing.T) {
 				}
 				return writeBlockHeader(store, secondBlockOffset, bh)
 			},
-			wantErr:     ErrCorrupted,
-			wantErrText: "invalid block entry version at offset",
 		},
 	}
 
@@ -538,12 +531,150 @@ func TestRecovery_CorruptionDetection(t *testing.T) {
 			// Apply corruption logic
 			require.NoError(t, tt.setupCorruption(store, blocks))
 
-			// Try to reopen the database - it should detect corruption
-			_, err := New(config.WithIndexDir(store.config.IndexDir).WithDataDir(store.config.DataDir), store.log)
+			db, err := New(config.WithIndexDir(store.config.IndexDir).WithDataDir(store.config.DataDir), store.log)
 			require.ErrorIs(t, err, tt.wantErr)
-			require.Contains(t, err.Error(), tt.wantErrText, "error message should contain expected text")
+			if tt.wantErr == nil {
+				block, err := db.Get(tt.blockHeights[0])
+				require.NoError(t, err)
+				require.Equal(t, blocks[0], block)
+				require.NoError(t, db.Close())
+			}
 		})
 	}
+}
+
+func TestRecoveryRebuildsTruncatedIndexAcrossDataFiles(t *testing.T) {
+	config := DefaultConfig().WithMaxDataFileSize(1024)
+	db := newDatabase(t, config)
+	// Fixed pseudo-random blocks force the second record into data file 1.
+	rng := rand.NewChaCha8([32]byte{})
+	blocks := make([][]byte, 2)
+	for height := range blocks {
+		blocks[height] = make([]byte, 512)
+		_, err := rng.Read(blocks[height])
+		require.NoError(t, err)
+		require.NoError(t, db.Put(uint64(height), blocks[height]))
+	}
+	firstEntry, err := db.readIndexEntry(0)
+	require.NoError(t, err)
+	require.NoError(t, db.Close())
+	require.FileExists(t, db.dataFilePath(1))
+
+	checkpointOffset := firstEntry.Offset + uint64(sizeOfBlockEntryHeader) + uint64(firstEntry.Size)
+	require.NoError(t, writeIndexFileHeader(db, 0, checkpointOffset))
+	require.NoError(t, os.Truncate(db.indexFile.Name(), int64(sizeOfIndexFileHeader+sizeOfIndexEntry)))
+
+	db = newDatabase(t, db.config)
+	for height, block := range blocks {
+		got, err := db.Get(uint64(height))
+		require.NoError(t, err)
+		require.Equal(t, block, got)
+	}
+	require.NoError(t, db.Close())
+}
+
+func TestRecoveryLeavesPartialRecordSuffix(t *testing.T) {
+	firstBlock := []byte("first block")
+	secondBlock := []byte("second block")
+	db := newDatabase(t, DefaultConfig())
+	require.NoError(t, db.Put(0, firstBlock))
+	require.NoError(t, db.Put(1, secondBlock))
+
+	firstEntry, err := db.readIndexEntry(0)
+	require.NoError(t, err)
+	secondEntry, err := db.readIndexEntry(1)
+	require.NoError(t, err)
+	require.NoError(t, db.Close())
+
+	checkpointOffset := firstEntry.Offset + uint64(sizeOfBlockEntryHeader) + uint64(firstEntry.Size)
+	// Treat the first block as checkpointed and truncate the later record mid-write.
+	require.NoError(t, writeIndexFileHeader(db, 0, checkpointOffset))
+	partialBlockEnd := secondEntry.Offset + uint64(sizeOfBlockEntryHeader) + uint64(secondEntry.Size)/2
+	require.NoError(t, os.Truncate(db.dataFilePath(0), int64(partialBlockEnd)))
+
+	db = newDatabase(t, db.config)
+	checkDatabaseState(t, db, 0)
+	got, err := db.Get(0)
+	require.NoError(t, err)
+	require.Equal(t, firstBlock, got)
+	_, err = db.Get(1)
+	require.ErrorIs(t, err, database.ErrNotFound)
+
+	replacement := []byte("replacement block")
+	require.NoError(t, db.Put(1, replacement))
+	got, err = db.Get(1)
+	require.NoError(t, err)
+	require.Equal(t, replacement, got)
+	require.NoError(t, db.Close())
+}
+
+func TestRecoveryLeavesIndexedDataAfterChecksumMismatch(t *testing.T) {
+	checkpointBlock := []byte("checkpoint block")
+	malformedBlock := []byte("malformed block")
+	indexedBlock := []byte("indexed block")
+	db := newDatabase(t, DefaultConfig())
+	require.NoError(t, db.Put(2, checkpointBlock))
+	require.NoError(t, db.Put(3, malformedBlock))
+	require.NoError(t, db.Put(5, indexedBlock))
+	malformedEntry, err := db.readIndexEntry(3)
+	require.NoError(t, err)
+	checkpointEntry, err := db.readIndexEntry(2)
+	require.NoError(t, err)
+	require.NoError(t, db.Close())
+
+	checkpointOffset := checkpointEntry.Offset + uint64(sizeOfBlockEntryHeader) + uint64(checkpointEntry.Size)
+	// Keep the checkpoint max below height 5 to exercise max-height recovery.
+	require.NoError(t, writeIndexFileHeader(db, 2, checkpointOffset))
+	require.NoError(t, os.Truncate(db.indexFile.Name(), int64(sizeOfIndexFileHeader+7*sizeOfIndexEntry)))
+	require.NoError(t, writeBlockHeader(db, int64(malformedEntry.Offset), blockEntryHeader{
+		Height:   3,
+		Size:     malformedEntry.Size,
+		Checksum: calculateChecksum(malformedBlock) + 1,
+		Version:  BlockEntryVersion,
+	}))
+
+	db = newDatabase(t, db.config)
+	checkDatabaseState(t, db, 5)
+	got, err := db.Get(5)
+	require.NoError(t, err)
+	require.Equal(t, indexedBlock, got)
+	_, err = db.Get(3)
+	require.ErrorIs(t, err, ErrCorrupted)
+	require.NoError(t, db.Close())
+
+	db = newDatabase(t, db.config)
+	checkDatabaseState(t, db, 5)
+	got, err = db.Get(5)
+	require.NoError(t, err)
+	require.Equal(t, indexedBlock, got)
+
+	replacement := randomBlock(t)
+	// A later Put must append after the preserved suffix without overwriting height 5.
+	require.NoError(t, db.Put(6, replacement))
+	got, err = db.Get(5)
+	require.NoError(t, err)
+	require.Equal(t, indexedBlock, got)
+	require.NoError(t, db.Close())
+}
+
+func writeIndexFileHeader(db *Database, maxHeight, nextWriteOffset uint64) error {
+	indexPath := db.indexFile.Name()
+	indexFile, err := os.OpenFile(indexPath, os.O_RDWR, 0)
+	if err != nil {
+		return err
+	}
+	defer indexFile.Close()
+
+	header := db.header
+	header.MaxHeight = maxHeight
+	header.NextWriteOffset = nextWriteOffset
+
+	headerBytes, err := header.MarshalBinary()
+	if err != nil {
+		return err
+	}
+	_, err = indexFile.WriteAt(headerBytes, 0)
+	return err
 }
 
 // Helper function to reset index file header to only a single block


### PR DESCRIPTION
## Why this should be merged

Allows reopening after malformed trailing data while preserving later valid indexed blocks, addressing item 6 in #5791. Completes the recovery work for #5879 on top of the checkpoint synchronization for item 8 in #5963.

Fixes #5879, depends on #5963.

## How this works

- Share record validation between reads and recovery, checking each record against its containing file.
- Rebuild complete records after the checkpoint. Preserve malformed suffixes, restore access to later valid indexed records, and append after the physical end.


## How this was tested

Unit tests.

## Need to be documented in RELEASES.md?

No.



