### PR TITLE
fix(load): don't cancel in-flight tests when the load timeout fires

### DIFF
--- a/tests/load/BUILD.bazel
+++ b/tests/load/BUILD.bazel
@@ -1,4 +1,5 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_library")
+load("//.bazel:defs.bzl", "go_test")
 
 go_library(
     name = "load",
@@ -24,5 +25,16 @@ go_library(
         "@com_github_prometheus_client_golang//prometheus",
         "@com_github_stretchr_testify//require",
         "@org_golang_x_sync//errgroup",
+    ],
+)
+
+go_test(
+    name = "load_test",
+    srcs = ["generator_test.go"],
+    embed = [":load"],
+    deps = [
+        "//tests",
+        "//utils/logging",
+        "@com_github_stretchr_testify//require",
     ],
 )

--- a/tests/load/README.md
+++ b/tests/load/README.md
@@ -45,7 +45,7 @@ The generator executes multiple tests concurrently against the network. The key 
 generator are as follows:
 
 - **Parallel Execution**: Runs a goroutine per wallet for concurrent test execution.
-- **Timeout Management**: Supports both overall load test timeout and a timeout per-test.
+- **Timeout Management**: Supports both an overall load test timeout and a per-test timeout. The load timeout stops new tests from being started but lets in-flight tests finish, so a run may overrun the load timeout by at most the per-test timeout.
 - **Error Recovery**: Automatically recovers from test failures to ensure continuous load generation.
 - **Metrics**: Creates metrics during wallet initialization and tracks performance throughout execution.
 

--- a/tests/load/generator.go
+++ b/tests/load/generator.go
@@ -61,6 +61,13 @@ func NewLoadGenerator(
 	}, nil
 }
 
+// Run executes the test on every wallet in a loop until ctx is cancelled or,
+// if loadTimeout is non-zero, until loadTimeout elapses.
+//
+// The load timeout only stops new iterations from starting. A test that is in
+// flight when it fires runs to completion under testTimeout, so Run may
+// overrun loadTimeout by at most testTimeout. Cancelling ctx still cancels
+// in-flight tests.
 func (l LoadGenerator) Run(
 	ctx context.Context,
 	log logging.Logger,
@@ -69,9 +76,11 @@ func (l LoadGenerator) Run(
 ) {
 	eg := &errgroup.Group{}
 
+	// loadCtx only gates new iterations; see Run's doc comment.
+	loadCtx := ctx
 	if loadTimeout != 0 {
-		childCtx, cancel := context.WithTimeout(ctx, loadTimeout)
-		ctx = childCtx
+		var cancel context.CancelFunc
+		loadCtx, cancel = context.WithTimeout(ctx, loadTimeout)
 		defer cancel()
 	}
 
@@ -79,7 +88,7 @@ func (l LoadGenerator) Run(
 		eg.Go(func() error {
 			for {
 				select {
-				case <-ctx.Done():
+				case <-loadCtx.Done():
 					return nil
 				default:
 				}

--- a/tests/load/generator_test.go
+++ b/tests/load/generator_test.go
@@ -1,0 +1,120 @@
+// Copyright (C) 2019, Ava Labs, Inc. All rights reserved.
+// See the file LICENSE for licensing terms.
+
+package load
+
+import (
+	"context"
+	"testing"
+	"testing/synctest"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/ava-labs/avalanchego/tests"
+	"github.com/ava-labs/avalanchego/utils/logging"
+)
+
+// blockingTest blocks its first run until released and then records the state
+// of its context parent. Any further run blocks forever.
+type blockingTest struct {
+	started chan struct{} // closed when the first run begins
+	release chan struct{} // closed by the test to let the first run finish
+
+	runs        int
+	ctxErr      error     // error of the context parent observed by the first run
+	ctxDeadline time.Time // deadline of the context parent observed by the first run
+}
+
+func newBlockingTest() *blockingTest {
+	return &blockingTest{
+		started: make(chan struct{}),
+		release: make(chan struct{}),
+	}
+}
+
+func (b *blockingTest) Run(tc tests.TestContext, _ *Wallet) {
+	b.runs++
+	if b.runs > 1 {
+		// An unexpected extra iteration deadlocks the synctest bubble and fails
+		// fast instead of spinning.
+		select {}
+	}
+
+	close(b.started)
+	<-b.release
+	ctx := tc.GetDefaultContextParent()
+	b.ctxErr = ctx.Err()
+	b.ctxDeadline, _ = ctx.Deadline()
+}
+
+// newTestLoadGenerator returns a generator with a single worker. The tests in
+// this file never touch the wallet, so it is left nil.
+func newTestLoadGenerator(test Test) LoadGenerator {
+	return LoadGenerator{
+		wallets: make([]*Wallet, 1),
+		test:    test,
+	}
+}
+
+// TestLoadGeneratorRunLoadTimeoutDoesNotCancelInFlightTest verifies that a test
+// in flight when the load timeout fires completes on an uncancelled context
+// bounded by testTimeout, and that no further iteration starts.
+func TestLoadGeneratorRunLoadTimeoutDoesNotCancelInFlightTest(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		const (
+			loadTimeout = time.Second
+			testTimeout = time.Minute
+		)
+
+		test := newBlockingTest()
+		generator := newTestLoadGenerator(test)
+
+		start := time.Now()
+		done := make(chan struct{})
+		go func() {
+			defer close(done)
+			generator.Run(t.Context(), logging.NoLog{}, loadTimeout, testTimeout)
+		}()
+
+		// Let the first iteration start and park in flight, then advance past
+		// the load timeout while it is still in flight.
+		<-test.started
+		time.Sleep(loadTimeout + time.Second)
+
+		close(test.release)
+		<-done
+
+		// The in-flight test must not have been cancelled by the load timeout,
+		// and its deadline must derive from testTimeout rather than loadTimeout.
+		require.NoError(t, test.ctxErr)
+		require.WithinDuration(t, start.Add(testTimeout), test.ctxDeadline, 0)
+		// No new iteration may start once the load timeout has fired.
+		require.Equal(t, 1, test.runs)
+	})
+}
+
+// TestLoadGeneratorRunStopsWhenContextCancelled verifies that, without a load
+// timeout, cancelling the caller's context still propagates to the in-flight
+// test and causes Run to return without starting further iterations.
+func TestLoadGeneratorRunStopsWhenContextCancelled(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		test := newBlockingTest()
+		generator := newTestLoadGenerator(test)
+
+		ctx, cancel := context.WithCancel(t.Context())
+		done := make(chan struct{})
+		go func() {
+			defer close(done)
+			generator.Run(ctx, logging.NoLog{}, 0, time.Minute)
+		}()
+
+		<-test.started
+		cancel()
+		close(test.release)
+		<-done
+
+		require.ErrorIs(t, test.ctxErr, context.Canceled)
+		require.Equal(t, 1, test.runs)
+	})
+}

--- a/tests/load/main/README.md
+++ b/tests/load/main/README.md
@@ -114,7 +114,7 @@ updated by the generator/wallets. The server is configured to be targeted by
 
 ### Load Test Flags
 
-- `--load-timeout`: Maximum duration to run the load test (default: unlimited)
+- `--load-timeout`: Duration to generate load for (default: unlimited). In-flight tests are allowed to finish, so the run may overrun this by up to the per-test timeout.
 - `--firewood`: Whether to use Firewood in Coreth (default: false)
 - `--num-workers`: The number of workers to use for the load test (default: 5)
 

--- a/tests/load/main/main.go
+++ b/tests/load/main/main.go
@@ -52,7 +52,7 @@ func init() {
 		&loadTimeoutArg,
 		"load-timeout",
 		0,
-		"the duration that the load test should run for",
+		"the duration that the load test should run for (in-flight tests are allowed to finish, so the run may overrun by up to the per-test timeout)",
 	)
 	flag.BoolVar(
 		&firewoodEnabledArg,


### PR DESCRIPTION
## Why this should be merged

Fixes #5913.

When `--load-timeout` expires, `LoadGenerator.Run` uses the timed-out context as the parent of every per-iteration test context. Workers only check the timeout between iterations, so a test that is in flight when the timeout fires has its transactions fail with a context cancellation. `require.NoError` then logs an `ERROR` with a full stack trace and calls `FailNow`, even though the run is ending on purpose. Timed load runs therefore end with spurious assertion failures that are indistinguishable from genuine ones, while the run itself still passes.

## How this works

The load timeout is decoupled from transaction cancellation, as proposed in the issue:

- The load timeout is used only to gate the start of new iterations (`loadCtx`).
- Each iteration derives its context from the caller's context plus `testTimeout`, so an in-flight test runs to completion instead of being cancelled.
- Cancelling the caller's context still propagates to in-flight tests and stops the generator, so shutdown semantics are unchanged.

The run stays bounded: it may overrun the load timeout by at most `testTimeout` (currently one minute). This is documented on `Run`, in both `tests/load` READMEs, and in the `--load-timeout` help text. The `test-load-ci` and `test-load-kube-kind-ci` tasks pass `--load-timeout=30s`, so their load phase may now take up to 90s instead of 30s.

## How this was tested

- Added `tests/load/generator_test.go` using `testing/synctest` for deterministic timing:
  - `TestLoadGeneratorRunLoadTimeoutDoesNotCancelInFlightTest`: a test in flight when the load timeout fires completes on an uncancelled context whose deadline derives from `testTimeout`, and no further iteration starts. Fails on the previous implementation with `context deadline exceeded`.
  - `TestLoadGeneratorRunStopsWhenContextCancelled`: without a load timeout, cancelling the caller's context still reaches the in-flight test and stops the generator.
- `go test -race -shuffle=on -count=30 ./tests/load/` and `./scripts/lint.sh ./tests/load/...` pass.
- End to end, against a local 5-node `tmpnet` network with `--load-timeout=20s`: the previous implementation logs one `Received unexpected error: context deadline exceeded` assertion failure per worker at the timeout; with this change the run completes without any.

## Need to be documented in RELEASES.md?

No. This only affects the load-test tooling under `tests/load`.