### PR TITLE
fix(platformvm): gate pre-Helicon block size on the block's own timestamp

### DIFF
--- a/vms/platformvm/block/executor/block.go
+++ b/vms/platformvm/block/executor/block.go
@@ -112,7 +112,21 @@ func (b *Block) Options(context.Context) ([2]snowman.Block, error) {
 }
 
 func (b *Block) verifyBlockSizePreHelicon() error {
-	if !b.manager.txExecutorBackend.Config.UpgradeConfig.IsHeliconActivated(b.Timestamp()) {
+	// Gate on the block's own timestamp, not b.Timestamp(): that method
+	// falls back to node-local chain time (the last-accepted block's
+	// timestamp) until this block is tracked in blkIDToState, which is not
+	// yet the case on a block's first verification. Since this is a
+	// consensus rule, it must not depend on node-local state: two nodes
+	// verifying the same block for the first time could otherwise disagree
+	// depending on their own progress through the chain, rather than on the
+	// block itself. Pre-Banff blocks have no stored timestamp and
+	// necessarily predate Helicon, so falling back to the zero value
+	// correctly selects the pre-Helicon limit for them.
+	var blkTime time.Time
+	if banffBlk, ok := b.Block.(platform.BanffBlock); ok {
+		blkTime = banffBlk.Timestamp()
+	}
+	if !b.manager.txExecutorBackend.Config.UpgradeConfig.IsHeliconActivated(blkTime) {
 		blockSize := len(b.Bytes())
 		if blockSize > codec.DefaultMaxSize {
 			b.manager.ctx.Log.Debug("block verification failed, block too big",

--- a/vms/platformvm/vm_test.go
+++ b/vms/platformvm/vm_test.go
@@ -2322,3 +2322,71 @@ func TestTxTooBig(t *testing.T) {
 		})
 	}
 }
+
+// TestBlockSizePreHeliconUsesBlockTimestamp reproduces
+// https://github.com/ava-labs/avalanchego/issues/5941: the pre-Helicon block
+// size gate must key off the block's own timestamp, not the node-local chain
+// time, or a legitimate post-Helicon block can be wrongly rejected by a node
+// whose chain time hasn't advanced past HeliconTime yet.
+func TestBlockSizePreHeliconUsesBlockTimestamp(t *testing.T) {
+	require := require.New(t)
+
+	vm, _, _ := defaultVM(t, upgradetest.Granite) // HeliconTime unscheduled
+	vm.ctx.Lock.Lock()
+	defer vm.ctx.Lock.Unlock()
+
+	// Schedule Helicon just after the chain's current (committed) timestamp,
+	// but move the wall clock up to meet it. The next built block will
+	// therefore be timestamped at/after HeliconTime, while the chain's
+	// committed timestamp -- what (*executor.Block).Timestamp() falls back
+	// to before a block is tracked -- remains behind it.
+	chainTime := vm.state.GetTimestamp()
+	heliconTime := chainTime.Add(time.Second)
+	vm.UpgradeConfig.HeliconTime = heliconTime
+	vm.clock.Set(heliconTime)
+	require.True(vm.UpgradeConfig.IsHeliconActivated(vm.clock.Time()))
+	require.False(vm.UpgradeConfig.IsHeliconActivated(vm.state.GetTimestamp()))
+
+	// Increase capacity so that the large tx passes gas validation.
+	vm.DynamicFeeConfig.MaxCapacity = 1_000_000
+	vm.state.SetFeeState(gas.State{Capacity: 1_000_000})
+
+	subnetID := testSubnet1.ID()
+	wallet := newWallet(t, vm, walletConfig{
+		subnetIDs: []ids.ID{subnetID},
+	})
+
+	// A genesis payload that makes the resulting block exceed
+	// codec.DefaultMaxSize. Admission relies on the wall clock (already past
+	// HeliconTime), so this is legal to include in a block.
+	bigGenesis := make([]byte, codec.DefaultMaxSize+1)
+	createChainTx, err := wallet.Builder().NewCreateChainTx(
+		subnetID,
+		bigGenesis,
+		ids.ID{'t', 'e', 's', 't', 'v', 'm'},
+		nil,
+		"big",
+	)
+	require.NoError(err)
+
+	bigTx := &platform.Tx{Unsigned: createChainTx}
+	require.NoError(wallet.Signer().Sign(t.Context(), bigTx))
+	require.NoError(vm.manager.VerifyTx(bigTx))
+
+	vm.ctx.Lock.Unlock()
+	require.NoError(vm.issueTxFromRPC(bigTx))
+	vm.ctx.Lock.Lock()
+
+	blk, err := vm.Builder.BuildBlock(t.Context())
+	require.NoError(err)
+	require.Greater(len(blk.Bytes()), codec.DefaultMaxSize)
+
+	banffBlk, ok := blk.(*blockexecutor.Block).Block.(platform.BanffBlock)
+	require.True(ok, "built block must be a Banff block")
+	require.False(banffBlk.Timestamp().Before(heliconTime), "built block must be timestamped at/after HeliconTime")
+
+	// The block's own timestamp is at/after HeliconTime, so it must be
+	// accepted even though the chain's committed timestamp has not reached
+	// HeliconTime yet.
+	require.NoError(blk.Verify(t.Context()))
+}


### PR DESCRIPTION
`verifyBlockSizePreHelicon` called `(*executor.Block).Timestamp()`, which falls back to node-local chain time (`backend.state.GetTimestamp()`) until the block is tracked in `blkIDToState` — which is not yet the case on a block's first verification.

Since this gates a consensus rule, depending on node-local state instead of the block's own timestamp lets two nodes reach different verdicts on the same block straddling the Helicon activation boundary: one whose chain time has already crossed `HeliconTime` accepts an oversized post-Helicon block, while another whose chain time hasn't caught up yet wrongly rejects it with `ErrBlockTooBigPreHelicon`.

Fixes this by reading the stateless block's own timestamp via `platform.BanffBlock`, matching how the Banff verifier visitors already select the Helicon rule (`verifier.go`).

Pre-Banff blocks have no stored timestamp and necessarily predate Helicon, so falling back to the zero value keeps applying the pre-Helicon limit for them.

Adds `TestBlockSizePreHeliconUsesBlockTimestamp`, which reproduces the divergence directly: it builds an oversized block whose own timestamp is at/after `HeliconTime` while the chain's committed timestamp is still behind it, and asserts verification succeeds.

Confirmed this test fails with `ErrBlockTooBigPreHelicon` when the fix is reverted.

Fixes #5941

Given Mainnet `HeliconTime` is `2026-09-22`, opening this now rather than waiting further given no response yet on the issue.